### PR TITLE
Fix UI cut-off when Primary Sidebar is on right

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -84,8 +84,8 @@
       "border-radius": "6px !important",
       "outline": "none !important"
    },
-   ".part.editor": {
-      "margin": "8px 8px 0 8px",
+    ".part.editor": {
+       "margin": "8px 16px 0 8px",
       "border-radius": "24px !important",
       "overflow": "hidden !important",
       "max-height": "calc(100% - 16px) !important",
@@ -158,9 +158,9 @@
       "border-radius": "10px !important",
       "width": "calc(100% - 14px) !important"
    },
-   ".part.activitybar": {
-      "background": "#121216 !important",
-      "margin": "8px 20px 30px 12px",
+    ".part.activitybar": {
+       "background": "#121216 !important",
+       "margin": "8px 20px 30px 8px",
       "width": "48px !important",
       "min-width": "48px !important"
    },


### PR DESCRIPTION
Fixes #1

## Changes

Updated margin settings in `settings.json` to fix the UI cut-off issue when the Primary Sidebar is moved to the right side:

1. **`.part.editor`** - Increased right margin from `8px` to `16px`
   - Changed: `"margin": "8px 16px 0 8px"`
   - This provides extra space on the right when sidebar is positioned there

2. **`.part.activitybar`** - Reduced left margin from `12px` to `8px`
   - Changed: `"margin": "8px 20px 30px 8px"`
   - Balanced spacing that works well whether sidebar is on left or right

## Why

When the Primary Sidebar is moved to the right, the right edge of the UI was getting cut off due to insufficient margin. These adjustments provide enough space for the sidebar while maintaining a balanced layout regardless of sidebar position.

## Testing

- [ ] Tested with Primary Sidebar on left
- [ ] Tested with Primary Sidebar on right

The 16px right margin on the editor provides room for the right-positioned sidebar, while the 8px left margin on the activitybar maintains visual spacing in both configurations.

Thanks to @Chewieez for identifying this issue and providing the initial fix!