### PR TITLE
Fix border line with non-Islands themes and consistent panel spacing

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,8 @@
 {
+  "workbench.colorCustomizations": {
+    "activityBar.border": "#00000000",
+    "sideBar.border": "#00000000"
+  },
   "workbench.colorTheme": "Islands Dark",
   "editor.fontFamily": "IBM Plex Mono",
   "terminal.integrated.fontFamily": "FiraCode Nerd Font Mono",
@@ -13,10 +17,10 @@
    },
    ".part.sidebar": {
       "font-family": "'Bear Sans UI', sans-serif !important",
-      "margin": "8px 8px 0 20px",
+      "margin": "8px 8px 8px 20px",
       "border-radius": "24px !important",
       "overflow": "hidden !important",
-      "max-height": "calc(100% - 8px) !important",
+      "max-height": "calc(100% - 16px) !important",
       "border-top": "1px solid rgba(255,255,255,0.1) !important",
       "border-left": "1px solid rgba(255,255,255,0.06) !important",
       "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
@@ -99,7 +103,7 @@
       "outline": "none !important"
    },
     ".part.editor": {
-       "margin": "8px 8px 0 8px",
+       "margin": "8px 8px 8px 8px",
       "border-radius": "24px !important",
       "overflow": "hidden !important",
       "max-height": "calc(100% - 16px) !important",
@@ -218,8 +222,10 @@
       "border-radius": "9999px !important"
    },
    ".part.panel.bottom": {
-      "margin": "0 8px",
-      "border-radius": "14px",
+      "margin": "8px 8px 8px 8px",
+      "border-radius": "24px !important",
+      "overflow": "clip !important",
+      "max-height": "calc(100% - 16px) !important",
       "border-top": "1px solid rgba(255,255,255,0.1) !important",
       "border-left": "1px solid rgba(255,255,255,0.06) !important",
       "border-bottom": "1px solid rgba(255,255,255,0.02) !important",


### PR DESCRIPTION
 1. Border line appearing with non-Islands base themes
 
When users use a base theme like "Default Dark Modern", a vertical border line appears behind the floating sidebar.
This is because Dark Modern sets activityBar.border and sideBar.border to #2B2B2B. Adding transparent colorCustomizations prevents this.

2. Inconsistent panel spacing.

The sidebar, editor, and bottom panel had no bottom margins, causing them to be flush against the bottom Added consistent 8px margins so all floating islands have equal spacing on all sides, matching the existing top and side spacing.

  3. Bottom panel tab clipping fix

Changed "overflow: hidden" to "overflow: clip" on the bottom panel to prevent the tab bar (Problems, Output, Terminal, etc.) from clipping when switching between panel views. "overflow: clip" provides the same visual clipping without interfering with VS Code's internal layout recalculations.

![LineDarkModern](https://github.com/user-attachments/assets/995de9ff-941a-49ad-aa3b-af0b5875cb84)