### PR TITLE
feat: add Windsurf IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## **THIS THEME IS STILL A WORK IN PROGRESS**
 
-A dark color theme for Visual Studio Code inspired by JetBrains' Islands Dark theme. Features floating glass-like panels, rounded corners, smooth animations, and a deeply refined UI.
+A dark color theme for Visual Studio Code and Windsurf inspired by JetBrains' Islands Dark theme. Features floating glass-like panels, rounded corners, smooth animations, and a deeply refined UI.
 
 ![Islands Dark Screenshot](assets/CleanShot%202026-02-14%20at%2021.47.05@2x.png)
 
@@ -59,7 +59,9 @@ If you prefer to clone first:
 ```bash
 git clone https://github.com/bwya77/vscode-dark-islands.git islands-dark
 cd islands-dark
-./install.sh
+./install.sh                  # auto-detects Windsurf or VS Code
+./install.sh --ide windsurf   # explicitly target Windsurf
+./install.sh --ide code       # explicitly target VS Code
 ```
 
 #### Windows
@@ -70,12 +72,20 @@ cd islands-dark
 .\install.ps1
 ```
 
+#### Install Script Options (macOS/Linux)
+
+| Option | Description |
+|---|---|
+| `--ide <windsurf\|code>` | Target IDE (default: auto-detect, prefers Windsurf) |
+| `--no-prompt` | Skip interactive prompts (useful for CI / IDE terminals) |
+| `-h, --help` | Show help message |
+
 The scripts will automatically:
 - ✅ Install the Islands Dark theme extension
 - ✅ Install the Custom UI Style extension
 - ✅ Install Bear Sans UI fonts
-- ✅ Merge settings into your VS Code: configuration
-- ✅ Enable Custom UI Style and reload VS Code:
+- ✅ Merge settings into your editor's configuration
+- ✅ Enable Custom UI Style and reload your editor
 
 > **Note:** IBM Plex Mono and FiraCode Nerd Font Mono must be installed separately (the script will remind you).
 
@@ -87,6 +97,16 @@ If you prefer to install manually, follow these steps:
 
 Clone this repo and copy the extension files:
 
+For **Windsurf**:
+```bash
+git clone https://github.com/bwya77/vscode-dark-islands.git islands-dark
+cd islands-dark
+mkdir -p ~/.windsurf/extensions/bwya77.islands-dark-1.0.0
+cp package.json ~/.windsurf/extensions/bwya77.islands-dark-1.0.0/
+cp -r themes ~/.windsurf/extensions/bwya77.islands-dark-1.0.0/
+```
+
+For **VS Code**:
 ```bash
 git clone https://github.com/bwya77/vscode-dark-islands.git islands-dark
 cd islands-dark
@@ -109,7 +129,7 @@ Copy-Item themes $ext\themes -Recurse
 
 The floating panels, rounded corners, glass borders, and animations are powered by the **Custom UI Style** extension.
 
-1. Open **Extensions** in VS Code: (`Cmd+Shift+X` / `Ctrl+Shift+X`)
+1. Open **Extensions** in your editor (`Cmd+Shift+X` / `Ctrl+Shift+X`)
 2. Search for **Custom UI Style** (by `subframe7536`)
 3. Click **Install**
 
@@ -117,7 +137,7 @@ The floating panels, rounded corners, glass borders, and animations are powered 
 
 For the best experience with the color-matched icon glow effect, install the **Seti Folder** icon theme:
 
-1. Open **Extensions** in VS Code (`Cmd+Shift+X` / `Ctrl+Shift+X`)
+1. Open **Extensions** in your editor (`Cmd+Shift+X` / `Ctrl+Shift+X`)
 2. Search for **[Seti Folder](https://marketplace.visualstudio.com/items?itemName=l-igh-t.vscode-theme-seti-folder)** (by `l-igh-t`)
 3. Click **Install**
 4. Set it as your icon theme: **Command Palette** > **Preferences: File Icon Theme** > **Seti Folder**
@@ -138,7 +158,7 @@ If you prefer different fonts, update the `editor.fontFamily`, `terminal.integra
 
 #### Step 6: Apply the settings
 
-Copy the contents of `settings.json` from this repo into your VS Code: settings:
+Copy the contents of `settings.json` from this repo into your editor's settings:
 
 1. Open **Command Palette** (`Cmd+Shift+P` / `Ctrl+Shift+P`)
 2. Search for **Preferences: Open User Settings (JSON)**
@@ -150,9 +170,9 @@ Copy the contents of `settings.json` from this repo into your VS Code: settings:
 
 1. Open **Command Palette** (`Cmd+Shift+P` / `Ctrl+Shift+P`)
 2. Run **Custom UI Style: Enable**
-3. VS Code will reload
+3. Your editor will reload
 
-> **Note:** You may see a "corrupt installation" warning after enabling. This is expected since Custom UI Style injects CSS into VS Code. Click the gear icon on the warning and select **Don't Show Again**.
+> **Note:** You may see a "corrupt installation" warning after enabling. This is expected since Custom UI Style injects CSS into the editor. Click the gear icon on the warning and select **Don't Show Again**.
 
 ## What the CSS customizations do
 
@@ -178,15 +198,15 @@ Copy the contents of `settings.json` from this repo into your VS Code: settings:
 ### Changes aren't taking effect
 Try disabling and re-enabling Custom UI Style:
 1. **Command Palette** > **Custom UI Style: Disable**
-2. Reload VS Code
+2. Reload your editor
 3. **Command Palette** > **Custom UI Style: Enable**
-4. Reload VS Code
+4. Reload your editor
 
 ### "Corrupt installation" warning
 This is expected after enabling Custom UI Style. Dismiss it or select **Don't Show Again**.
 
 ### Previously used "Custom CSS and JS Loader" extension
-If you previously used the **Custom CSS and JS Loader** extension (`be5invis.vscode-custom-css`), it may have injected CSS directly into VS Code's `workbench.html` that persists even after disabling. If styles conflict, reinstall VS Code to get a clean `workbench.html`, then use only **Custom UI Style**.
+If you previously used the **Custom CSS and JS Loader** extension (`be5invis.vscode-custom-css`), it may have injected CSS directly into the editor's `workbench.html` that persists even after disabling. If styles conflict, reinstall your editor to get a clean `workbench.html`, then use only **Custom UI Style**.
 
 ## Credits
 

--- a/install.sh
+++ b/install.sh
@@ -2,28 +2,108 @@
 
 set -e
 
-echo "🏝️  Islands Dark Theme Installer for macOS/Linux"
-echo "================================================"
-echo ""
-
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Check if code command is available
-if ! command -v code &> /dev/null; then
-    echo -e "${RED}❌ Error: VS Code CLI (code) not found!${NC}"
-    echo "Please install VS Code and make sure 'code' command is in your PATH."
-    echo "You can do this by:"
-    echo "  1. Open VS Code"
-    echo "  2. Press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Linux)"
-    echo "  3. Type 'Shell Command: Install code command in PATH'"
+# --- Parse arguments ---
+TARGET_IDE=""
+show_help() {
+    echo "Usage: $0 [--ide <windsurf|code>] [--no-prompt]"
+    echo ""
+    echo "Options:"
+    echo "  --ide <windsurf|code>  Target IDE (default: auto-detect)"
+    echo "  --no-prompt            Skip interactive prompts"
+    echo "  -h, --help             Show this help message"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ide)
+            TARGET_IDE="$2"
+            shift 2
+            ;;
+        --no-prompt)
+            ISLANDS_DARK_NO_PROMPT=1
+            shift
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            show_help
+            ;;
+    esac
+done
+
+# Validate --ide value if provided
+if [ -n "$TARGET_IDE" ] && [ "$TARGET_IDE" != "windsurf" ] && [ "$TARGET_IDE" != "code" ]; then
+    echo -e "${RED}❌ Invalid --ide value: $TARGET_IDE${NC}"
+    echo "   Supported values: windsurf, code"
     exit 1
 fi
 
-echo -e "${GREEN}✓ VS Code CLI found${NC}"
+# Auto-detect if --ide not specified
+if [ -z "$TARGET_IDE" ]; then
+    if command -v windsurf &> /dev/null; then
+        TARGET_IDE="windsurf"
+    elif command -v code &> /dev/null; then
+        TARGET_IDE="code"
+    else
+        echo -e "${RED}❌ No supported editor CLI found (windsurf / code)${NC}"
+        echo "   Please specify the target IDE manually: $0 --ide <windsurf|code>"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Auto-detected IDE: $TARGET_IDE${NC}"
+fi
+
+# --- Set IDE-specific paths ---
+if [ "$TARGET_IDE" = "windsurf" ]; then
+    IDE_NAME="Windsurf"
+    EDITOR_CLI="windsurf"
+    EXT_BASE_DIR="$HOME/.windsurf/extensions"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        SETTINGS_DIR="$HOME/Library/Application Support/Windsurf/User"
+    else
+        SETTINGS_DIR="$HOME/.config/Windsurf/User"
+    fi
+else
+    IDE_NAME="VS Code"
+    EDITOR_CLI="code"
+    EXT_BASE_DIR="$HOME/.vscode/extensions"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        SETTINGS_DIR="$HOME/Library/Application Support/Code/User"
+    else
+        SETTINGS_DIR="$HOME/.config/Code/User"
+    fi
+fi
+
+# Allow env override for settings directory
+if [ -n "${ISLANDS_DARK_SETTINGS_DIR:-}" ]; then
+    SETTINGS_DIR="$ISLANDS_DARK_SETTINGS_DIR"
+fi
+
+# Check if the chosen CLI is actually available
+HAS_CLI=true
+if ! command -v "$EDITOR_CLI" &> /dev/null; then
+    HAS_CLI=false
+fi
+
+echo "🏝️  Islands Dark Theme Installer for macOS/Linux"
+echo "================================================"
+echo -e "   Target IDE: ${GREEN}${IDE_NAME}${NC}"
+echo ""
+
+if [ "$HAS_CLI" = true ]; then
+    echo -e "${GREEN}✓ $IDE_NAME CLI found: $EDITOR_CLI${NC}"
+else
+    echo -e "${YELLOW}⚠️  $IDE_NAME CLI ($EDITOR_CLI) not found in PATH${NC}"
+    echo "   Will skip automatic marketplace installs and window reload."
+fi
 
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -31,8 +111,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo ""
 echo "📦 Step 1: Installing Islands Dark theme extension..."
 
-# Install by copying to VS Code extensions directory
-EXT_DIR="$HOME/.vscode/extensions/bwya77.islands-dark-1.0.0"
+# Install by copying to extensions directory
+EXT_DIR="$EXT_BASE_DIR/bwya77.islands-dark-1.0.0"
 rm -rf "$EXT_DIR"
 mkdir -p "$EXT_DIR"
 cp "$SCRIPT_DIR/package.json" "$EXT_DIR/"
@@ -47,11 +127,16 @@ fi
 
 echo ""
 echo "🔧 Step 2: Installing Custom UI Style extension..."
-if code --install-extension subframe7536.custom-ui-style --force; then
-    echo -e "${GREEN}✓ Custom UI Style extension installed${NC}"
+if [ "$HAS_CLI" = true ]; then
+    if "$EDITOR_CLI" --install-extension subframe7536.custom-ui-style --force; then
+        echo -e "${GREEN}✓ Custom UI Style extension installed${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Could not install Custom UI Style extension automatically${NC}"
+        echo "   Please install it manually from the $IDE_NAME Extensions marketplace"
+    fi
 else
-    echo -e "${YELLOW}⚠️  Could not install Custom UI Style extension automatically${NC}"
-    echo "   Please install it manually from the Extensions marketplace"
+    echo -e "${YELLOW}⚠️  Skipping automatic install: $IDE_NAME CLI not available${NC}"
+    echo "   Please install manually: subframe7536.custom-ui-style"
 fi
 
 echo ""
@@ -77,11 +162,7 @@ else
 fi
 
 echo ""
-echo "⚙️  Step 4: Applying VS Code settings..."
-SETTINGS_DIR="$HOME/.config/Code/User"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    SETTINGS_DIR="$HOME/Library/Application Support/Code/User"
-fi
+echo "⚙️  Step 4: Applying $IDE_NAME settings..."
 
 mkdir -p "$SETTINGS_DIR"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
@@ -97,7 +178,7 @@ if [ -f "$SETTINGS_FILE" ]; then
 
     # Create a temporary file with the merge logic using node.js if available
     if command -v node &> /dev/null; then
-        node << 'NODE_SCRIPT'
+        SCRIPT_DIR="$SCRIPT_DIR" SETTINGS_FILE="$SETTINGS_FILE" node << 'NODE_SCRIPT'
 const fs = require('fs');
 const path = require('path');
 
@@ -112,17 +193,13 @@ function stripJsonc(text) {
     return text;
 }
 
-const scriptDir = process.cwd();
-const newSettings = JSON.parse(stripJsonc(fs.readFileSync(path.join(scriptDir, 'settings.json'), 'utf8')));
-
-let settingsDir;
-if (process.platform === 'darwin') {
-    settingsDir = path.join(process.env.HOME, 'Library/Application Support/Code/User');
-} else {
-    settingsDir = path.join(process.env.HOME, '.config/Code/User');
+const scriptDir = process.env.SCRIPT_DIR || process.cwd();
+const settingsFile = process.env.SETTINGS_FILE;
+if (!settingsFile) {
+    throw new Error('SETTINGS_FILE env not set');
 }
 
-const settingsFile = path.join(settingsDir, 'settings.json');
+const newSettings = JSON.parse(stripJsonc(fs.readFileSync(path.join(scriptDir, 'settings.json'), 'utf8')));
 const existingText = fs.readFileSync(settingsFile, 'utf8');
 const existingSettings = JSON.parse(stripJsonc(existingText));
 
@@ -142,7 +219,7 @@ fs.writeFileSync(settingsFile, JSON.stringify(mergedSettings, null, 2));
 console.log('Settings merged successfully');
 NODE_SCRIPT
     else
-        echo -e "${YELLOW}   Node.js not found. Please manually merge settings.json from this repo into your VS Code settings.${NC}"
+        echo -e "${YELLOW}   Node.js not found. Please manually merge settings.json from this repo into your $IDE_NAME settings.${NC}"
         echo "   Your original settings have been backed up to settings.json.backup"
     fi
 else
@@ -153,7 +230,7 @@ fi
 
 echo ""
 echo "🚀 Step 5: Enabling Custom UI Style..."
-echo "   VS Code will reload after applying changes..."
+echo "   Your editor will reload after applying changes..."
 
 # Create a flag file to indicate first run
 FIRST_RUN_FILE="$SCRIPT_DIR/.islands_dark_first_run"
@@ -162,31 +239,36 @@ if [ ! -f "$FIRST_RUN_FILE" ]; then
     echo ""
     echo -e "${YELLOW}📝 Important Notes:${NC}"
     echo "   • IBM Plex Mono and FiraCode Nerd Font Mono need to be installed separately"
-    echo "   • After VS Code reloads, you may see a 'corrupt installation' warning"
+    echo "   • After $IDE_NAME reloads, you may see a 'corrupt installation' warning"
     echo "   • This is expected - click the gear icon and select 'Don't Show Again'"
     echo ""
-    if [ -t 0 ]; then
-        read -p "Press Enter to continue and reload VS Code..."
+    if [ -t 0 ] && [ "${ISLANDS_DARK_NO_PROMPT:-0}" != "1" ]; then
+        read -p "Press Enter to continue and reload..."
     fi
 fi
 
 # Apply custom UI style
 echo "   Applying CSS customizations..."
 
-# Reload VS Code to apply changes
+# Reload editor to apply changes
 echo -e "${GREEN}✓ Setup complete!${NC}"
 echo ""
 echo "🎉 Islands Dark theme has been installed!"
-echo "   VS Code will now reload to apply the custom UI style."
+echo "   Your editor will now reload to apply the custom UI style."
 echo ""
 
-# Use AppleScript on macOS to show a notification and reload VS Code
+# Use AppleScript on macOS to show a notification
 if [[ "$OSTYPE" == "darwin"* ]]; then
     osascript -e 'display notification "Islands Dark theme installed successfully!" with title "🏝️ Islands Dark"' 2>/dev/null || true
 fi
 
-echo "   Reloading VS Code..."
-code --reload-window 2>/dev/null || code . 2>/dev/null || true
+if [ "$HAS_CLI" = true ]; then
+    echo "   Reloading $IDE_NAME..."
+    "$EDITOR_CLI" --reload-window 2>/dev/null || "$EDITOR_CLI" "$SCRIPT_DIR" 2>/dev/null || true
+else
+    echo -e "${YELLOW}⚠️  Skipping reload: $IDE_NAME CLI not available${NC}"
+    echo "   Please restart $IDE_NAME manually to apply changes."
+fi
 
 echo ""
 echo -e "${GREEN}Done! 🏝️${NC}"


### PR DESCRIPTION
- Update install.sh to auto-detect Windsurf or VS Code (prefers Windsurf)
- Add --ide flag to explicitly target windsurf or code
- Add --no-prompt flag to skip interactive prompts for CI/non-interactive shells
- Set IDE-specific paths for extensions and settings directories
- Skip CLI-dependent operations when editor CLI not found in PATH
- Update README with Windsurf references throughout
- Add install script options table to README