### PR TITLE
Fix unintended activity bar separator line

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -458,4 +458,8 @@
    }
   },
   "workbench.iconTheme": "vs-seti-folder"
+  "workbench.colorCustomizations": {
+  "activityBar.border": "#00000000",
+  "sideBar.border": "#00000000"
+  }
 }


### PR DESCRIPTION
Caused by margins and layout spacing, the internal separator no longer aligned with the sidebar so it looked like a random floating line.