### PR TITLE
Fix activity bar icon spacing and editor/sidebar overlap

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,7 +13,7 @@
    },
    ".part.sidebar": {
       "font-family": "'Bear Sans UI', sans-serif !important",
-      "margin": "8px 8px 0 20px",
+      "margin": "8px 0 0 20px",
       "border-radius": "24px !important",
       "overflow": "hidden !important",
       "max-height": "calc(100% - 8px) !important",
@@ -99,7 +99,7 @@
       "outline": "none !important"
    },
     ".part.editor": {
-       "margin": "8px 8px 0 8px",
+       "margin": "8px 8px 0 20px",
       "border-radius": "24px !important",
       "overflow": "hidden !important",
       "max-height": "calc(100% - 16px) !important",
@@ -292,13 +292,16 @@
       "align-items": "center !important",
       "justify-content": "center !important",
       "width": "100% !important",
-      "overflow": "visible !important"
+      "overflow": "visible !important",
+      "gap": "6px !important"
    },
    ".part.activitybar .action-item": {
       "display": "flex !important",
       "justify-content": "center !important",
       "width": "100% !important",
-      "overflow": "visible !important"
+      "overflow": "visible !important",
+      "margin-top": "4px !important",
+      "margin-bottom": "4px !important"
    },
    ".part.activitybar .badge": {
       "z-index": "10 !important",


### PR DESCRIPTION
## Summary
- Increase editor left margin (`8px` → `20px`) to prevent overlap with activity bar island when sidebar is collapsed
- Reduce sidebar right margin (`8px` → `0`) to prevent excessive gap between sidebar and editor islands when sidebar is expanded
- Add `gap: 6px` and `margin-top/bottom: 4px` to activity bar icons for proper vertical spacing

Fixes #16

## Test plan
- [x] Collapse sidebar — verify activity bar and editor islands don't overlap
- [x] Expand sidebar — verify no excessive gap between sidebar and editor
- [x] Check activity bar icons have even vertical spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)