### PR TITLE
fix: remove explorer scaleY transforms and terminal tabs width overrides

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -58,14 +58,6 @@
    ".part.sidebar .pane-header .title": {
       "font-size": "10px !important"
    },
-   ".explorer-folders-view .monaco-list-rows": {
-      "transform": "translate3d(0px, 0px, 0px) scaleY(1.15) !important",
-      "transform-origin": "top left !important"
-   },
-   ".explorer-folders-view .monaco-tl-row": {
-      "transform": "scaleY(0.87) !important",
-      "transform-origin": "top left !important"
-   },
    ".part.sidebar .monaco-list-row": {
       "border-radius": "6px !important",
       "margin-left": "4px !important",
@@ -165,14 +157,6 @@
    },
    ".monaco-breadcrumbs:hover *": {
       "opacity": "1 !important"
-   },
-   ".split-view-view:has(.terminal-tabs-entry)": {
-      "min-width": "220px !important"
-   },
-   ".split-view-view:has(.terminal-tabs-entry) .monaco-list-row": {
-      "border-radius": "6px !important",
-      "margin-right": "20px !important",
-      "width": "calc(100% - 20px) !important"
    },
    ".viewpane-filter .monaco-inputbox": {
       "border-radius": "9999px !important"


### PR DESCRIPTION
## Summary
- Remove `scaleY(1.15)` / `scaleY(0.87)` transforms on `.explorer-folders-view` rows that break VS Code's virtualized list — causes files beyond a certain depth to disappear and mouse scrolling to stop working
- Remove `min-width: 220px`, `margin-right: 20px`, and `width: calc(100% - 20px)` on terminal tab rows that clip the close (X) button when the terminal tabs panel is narrower than 220px

## Root cause

**Explorer:** VS Code uses a virtualized list for the file explorer. The CSS transforms scale rows visually but the scroll position calculations still use original dimensions, causing items to become unreachable and scroll to break entirely.

**Terminal tabs:** The forced `min-width: 220px` on the terminal tabs container combined with `width: calc(100% - 20px)` and `margin-right: 20px` on each row clips the action buttons (close/X) at the right edge when the panel is narrower than the forced minimum.

## Fixes
- Fixes #27 (Explorer not showing folders beyond a certain depth)
- Fixes #12 (Too many items in file explorer break it)
- Fixes #20 (Some files are not being displayed via the explorer)

## Test plan
- [ ] Open a project with deeply nested folders — all files/folders should be visible and scrollable
- [ ] Open multiple terminals — the close (X) button should be visible on hover in the terminal tabs panel
- [ ] Resize the terminal tabs panel to various widths — no clipping should occur