### PR TITLE
feat: add nix flake installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.vsix
 node_modules/
+result/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,36 @@ The scripts will automatically:
 
 > **Note:** IBM Plex Mono and FiraCode Nerd Font Mono must be installed separately (the script will remind you).
 
+### Nix Flake Install
+
+If you use Nix, you can run a pre-configured instance of VS Code (or VSCodium) with the theme, extensions, and fonts already bundled.
+
+To run it directly without installing:
+
+```bash
+# Run VS Code
+nix run github:bwya77/vscode-dark-islands#vscode
+
+# Or run VSCodium
+nix run github:bwya77/vscode-dark-islands#vscodium
+```
+
+To use it in your NixOS or Home Manager configuration, add it to your flake inputs:
+
+```nix
+{
+  inputs.islands-dark.url = "github:bwya77/vscode-dark-islands";
+
+  outputs = { self, nixpkgs, islands-dark, ... }: {
+    # Then you can add and use it:
+    # islands-dark.packages.${pkgs.stdenv.hostPlatform.system}.vscode
+    # islands-dark.packages.${pkgs.stdenv.hostPlatform.system}.vscodium
+  };
+}
+```
+
+> **Note:** The Nix flake automatically includes the **Custom UI Style** extension, **Seti Folder** icon theme, and all required fonts (**Bear Sans UI**, **IBM Plex Mono**, and **FiraCode Nerd Font**). It will also copy the recommended `settings.json` on the first run.
+
 ### Manual Installation
 
 If you prefer to install manually, follow these steps:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,170 @@
+{
+  description = "Islands Dark Theme for VS Code";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        islandsDarkExtension = pkgs.stdenv.mkDerivation {
+          pname = "islands-dark";
+          version = "0.0.2";
+          src = ./.;
+
+          installPhase = ''
+            mkdir -p "$out/share/vscode/extensions/bwya77.islands-dark"
+            cp -r package.json themes "$out/share/vscode/extensions/bwya77.islands-dark/"
+          '';
+
+          passthru = {
+            vscodeExtUniqueId = "bwya77.islands-dark";
+            vscodeExtPublisher = "bwya77";
+            vscodeExtName = "islands-dark";
+          };
+        };
+
+        setiFolderExtension = pkgs.vscode-utils.buildVscodeMarketplaceExtension {
+          mktplcRef = {
+            name = "vscode-theme-seti-folder";
+            publisher = "l-igh-t";
+            version = "1.3.0";
+            sha256 = "0y3bcgsdi3qcy4vj82a3m53dfil95p8qvc50rxdbnii8nxgcjan5";
+          };
+        };
+
+        bearSansUiFonts = pkgs.stdenv.mkDerivation {
+          pname = "bear-sans-ui";
+          version = "1.0.0";
+          src = ./fonts;
+          installPhase = ''
+            mkdir -p $out/share/fonts/opentype
+            cp *.otf $out/share/fonts/opentype/
+          '';
+        };
+
+        islandsDarkFonts = pkgs.symlinkJoin {
+          name = "islands-dark-fonts";
+          paths = [
+            bearSansUiFonts
+            pkgs.ibm-plex
+            (pkgs.nerd-fonts.fira-code or (pkgs.nerdfonts.override { fonts = [ "FiraCode" ]; }))
+          ];
+        };
+
+        settingsJson = builtins.fromJSON (builtins.readFile ./settings.json);
+
+        # Extract the CSS object from settings.json
+        customCssObj = settingsJson."custom-ui-style.stylesheet" or {};
+
+        # Convert the JSON object into a valid CSS string
+        toCss = obj:
+          builtins.concatStringsSep "\n" (
+            pkgs.lib.mapAttrsToList (selector: rules:
+              "${selector} {\n" +
+              builtins.concatStringsSep "\n" (
+                pkgs.lib.mapAttrsToList (prop: value: "  ${prop}: ${value};") rules
+              ) +
+              "\n}"
+            ) obj
+          );
+
+        customCssString = toCss customCssObj;
+
+        mkVscode = { vscodePackage ? pkgs.vscode, extraExtensions ? [] }:
+          let
+            # PATCH AT BUILD TIME: Instead of relying on the extension to modify files at runtime
+            # (which fails on a read-only Nix store), we append the CSS directly to VS Code's core
+            # CSS file during the build phase.
+            patchedVscode = vscodePackage.overrideAttrs (old: {
+              postInstall = (old.postInstall or "") + ''
+                CSS_FILE=$(find $out/lib -name "workbench.desktop.main.css" | head -n 1)
+                if [ -n "$CSS_FILE" ]; then
+                  echo "Appending custom CSS to $CSS_FILE"
+                  cat ${pkgs.writeText "islands-dark.css" customCssString} >> "$CSS_FILE"
+                else
+                  echo "Warning: workbench.desktop.main.css not found!"
+                fi
+              '';
+            });
+
+            vscodeWithExts = pkgs.vscode-with-extensions.override {
+              vscode = patchedVscode;
+              vscodeExtensions = [
+                islandsDarkExtension
+                setiFolderExtension
+              ] ++ extraExtensions;
+            };
+
+            configDirName = if vscodePackage.pname == "vscodium" then "VSCodium" else "Code";
+            executableName = vscodePackage.meta.mainProgram or (if vscodePackage.pname == "vscodium" then "codium" else "code");
+
+          in pkgs.symlinkJoin {
+            name = "islands-dark-${vscodePackage.pname}";
+            paths = [ vscodeWithExts ];
+            buildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/${executableName} \
+                --run '
+                  # Apply settings.json on first run
+                  if [ "$(uname)" = "Darwin" ]; then
+                    CONFIG_DIR="$HOME/Library/Application Support/${configDirName}/User"
+                  else
+                    CONFIG_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/${configDirName}/User"
+                  fi
+
+                  mkdir -p "$CONFIG_DIR"
+                  FLAG_FILE="$CONFIG_DIR/.islands_dark_first_run"
+
+                  if [ ! -f "$FLAG_FILE" ]; then
+                    if [ -f "$CONFIG_DIR/settings.json" ]; then
+                      cp "$CONFIG_DIR/settings.json" "$CONFIG_DIR/settings.json.pre-islands-dark"
+                    fi
+                    rm -f "$CONFIG_DIR/settings.json"
+                    cp ${./settings.json} "$CONFIG_DIR/settings.json"
+                    chmod 644 "$CONFIG_DIR/settings.json"
+                    touch "$FLAG_FILE"
+                  fi
+                '
+            '';
+            meta = (vscodePackage.meta or {}) // {
+              mainProgram = executableName;
+            };
+          };
+
+      in
+      {
+        packages = {
+          default = mkVscode { vscodePackage = pkgs.vscode; };
+          vscode = mkVscode { vscodePackage = pkgs.vscode; };
+          vscodium = mkVscode { vscodePackage = pkgs.vscodium; };
+
+          extension-islands-dark = islandsDarkExtension;
+          extension-seti-folder = setiFolderExtension;
+
+          fonts = islandsDarkFonts;
+        };
+
+        lib = {
+          inherit mkVscode;
+          settings = settingsJson;
+        };
+
+        overlays.default = final: prev: {
+          islands-dark = {
+            vscode = mkVscode { vscodePackage = prev.vscode; };
+            vscodium = mkVscode { vscodePackage = prev.vscodium; };
+            extensions = {
+              islands-dark = islandsDarkExtension;
+              seti-folder = setiFolderExtension;
+            };
+            fonts = islandsDarkFonts;
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
### Add Nix Flake support

This PR adds a `flake.nix` to provide a reproducible and easy installation of the Islands Dark theme for Nix/NixOS users.

**Changes:**
- Packages the local `islands-dark` extension, required fonts (Bear Sans UI, IBM Plex Mono, FiraCode Nerd Font), and recommended marketplace extensions (Custom UI Style, Seti Folder) into a custom VS Code/VSCodium derivation.
- Injects the custom CSS at build time to bypass `EROFS: read-only file system` errors on NixOS (not using the custom ui extension).
- Includes a wrapper script to automatically apply the recommended `settings.json` on the first run.
- Updated `README.md` with Nix installation instructions.
