### PR TITLE
Remove redundant `.tab .monaco-icon-label.file-icon::before` style rule

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -348,10 +348,6 @@
       "filter": "drop-shadow(0 0 2.5px currentColor)",
       "opacity": "1 !important"
    },
-   ".tab .monaco-icon-label.file-icon::before": {
-      "filter": "drop-shadow(0 0 2.5px currentColor)",
-      "opacity": "1 !important"
-   },
    ".letterpress": {
       "opacity": "0.4 !important",
       "filter": "brightness(0) drop-shadow(2px 2px 1px rgba(255,255,255,0.12)) drop-shadow(-2px -2px 1px rgba(0,0,0,1)) !important"


### PR DESCRIPTION
This PR removes a duplicated style rule in `settings.json`.

The following two selectors defined the exact same styles:

- `.monaco-icon-label.file-icon::before`
- `.tab .monaco-icon-label.file-icon::before`

Since the scoped version under `.tab` did not add any additional behavior, it was redundant.
Removing it simplifies the theme settings without changing the visual output.

Closes #88
