### PR TITLE
Delete broken extensions.json during install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -62,6 +62,14 @@ if (Test-Path "$extDir\themes") {
     exit 1
 }
 
+# Remove extensions.json so VS Code rebuilds it cleanly on next launch
+# (previous versions of this script wrote invalid content to this file)
+$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
+if (Test-Path $extJsonPath) {
+    Remove-Item $extJsonPath -Force
+    Write-Host "Cleared extensions.json (VS Code will rebuild it)" -ForegroundColor Green
+}
+
 Write-Host ""
 Write-Host "Step 2: Installing Custom UI Style extension..."
 try {

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,14 @@ else
     exit 1
 fi
 
+# Remove extensions.json so VS Code rebuilds it cleanly on next launch
+# (previous versions of this script wrote invalid content to this file)
+EXT_JSON="$HOME/.vscode/extensions/extensions.json"
+if [ -f "$EXT_JSON" ]; then
+    rm -f "$EXT_JSON"
+    echo -e "${GREEN}✓ Cleared extensions.json (VS Code will rebuild it)${NC}"
+fi
+
 echo ""
 echo "🔧 Step 2: Installing Custom UI Style extension..."
 if code --install-extension subframe7536.custom-ui-style --force; then


### PR DESCRIPTION
## Summary
- Install scripts now delete the leftover broken `extensions.json` before proceeding
- Previous versions of the script wrote invalid content to this file, which persisted across re-installs and prevented VS Code from discovering any extensions
- VS Code rebuilds `extensions.json` cleanly on next launch

## Test plan
- [ ] Run `install.ps1` on Windows — verify extensions.json is deleted and VS Code discovers extensions on reload
- [ ] Run `install.sh` on macOS — verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)