### PR TITLE
Reload VS Code twice on Windows to apply Custom UI Style CSS

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -152,9 +152,13 @@ Write-Host "Islands Dark theme has been installed!" -ForegroundColor Green
 Write-Host "   VS Code will now reload to apply the custom UI style."
 Write-Host ""
 
-# Reload VS Code
-Write-Host "   Reloading VS Code..." -ForegroundColor Cyan
+# Reload VS Code twice — first reload activates Custom UI Style and patches
+# VS Code's CSS, second reload applies the patched CSS
+Write-Host "   Reloading VS Code to activate Custom UI Style..." -ForegroundColor Cyan
 try {
+    code --reload-window 2>$null
+    Start-Sleep -Seconds 5
+    Write-Host "   Reloading VS Code to apply CSS customizations..." -ForegroundColor Cyan
     code --reload-window 2>$null
 } catch {
     code $scriptDir 2>$null


### PR DESCRIPTION
## Summary
- The Custom UI Style extension needs two reloads to fully take effect: the first activates the extension and patches VS Code's CSS files, the second reload applies the patched CSS
- Added a 5-second delay between reloads to allow the extension to finish patching
- Windows only — the first reload was not sufficient for the CSS customizations to appear

## Test plan
- [ ] Run `install.ps1` on Windows — verify the theme and CSS customizations are fully applied without needing a manual reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)