### PR TITLE
changed copilot chat styling to become more consistent

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -538,7 +538,17 @@
    },
    ".chat-editing-session-container": {
       "border-radius": "var(--islands-input-radius) !important",
-      "overflow": "hidden !important"
+      "overflow": "hidden !important",
+      "background-color": "var(--islands-bg-surface) !important"
+   },
+   ".agent-sessions-title": {
+      "font-size": "10px !important",
+      "letter-spacing": "0.05em !important"
+   },
+   ".chat-editing-session-container .pane-header": {
+      "min-height": "20px !important",
+      "height": "20px !important",
+      "line-height": "20px !important"
    },
    ".chat-confirmation-widget2": {
       "border-radius": "var(--islands-input-radius) !important",
@@ -555,6 +565,12 @@
    },
    ".chat-input-container .monaco-inputbox": {
       "background-color": "var(--islands-bg-surface) !important"
+   },
+   ".chat-input-container .chat-attached-context": {
+      "background-color": "var(--islands-bg-surface) !important"
+   },
+   ".chat-input-container .chat-attached-context .chat-attached-context-attachment": {
+      "background-color": "transparent !important"
    },
    ".interactive-input-part": {
       "border-radius": "var(--islands-widget-radius) !important",


### PR DESCRIPTION
The new changed style for copilot chat:
<img width="301" height="804" alt="Screenshot 2026-02-26 at 7 45 14 PM" src="https://github.com/user-attachments/assets/92bb3e14-1301-4336-b9b0-a4375de8fd26" />

This makes the chat more consistent in colour with the rest of the editor.

Closes #100