### PR TITLE
fix: make inactive items same height like activeu one and prevent jumping whole activity bar

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -330,7 +330,10 @@
       "display": "flex !important",
       "align-items": "center !important",
       "justify-content": "center !important",
-      "overflow": "visible !important"
+      "overflow": "visible !important",
+      "border-radius": "50% !important",
+      "border": "1px solid transparent !important",
+      "box-sizing": "border-box !important"
    },
    ".part.activitybar .action-item .action-label .codicon": {
       "font-size": "22px !important"
@@ -345,8 +348,8 @@
    ".part.activitybar .action-item.checked .action-label": {
       "background": "linear-gradient(180deg, rgba(55,56,62,0.9), rgba(40,41,46,0.7)) !important",
       "border-radius": "50% !important",
-      "width": "30px !important",
-      "height": "30px !important",
+      "width": "34px !important",
+      "height": "34px !important",
       "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.12), inset 1px 0 0 0 rgba(255,255,255,0.06), inset 0 -1px 0 0 rgba(255,255,255,0.02), inset -1px 0 0 0 rgba(255,255,255,0.02), inset 0 1px 2px 0 rgba(255,255,255,0.05), 0 1px 3px 0 rgba(0,0,0,0.3) !important"
    },
    ".part.activitybar .actions-container": {


### PR DESCRIPTION
Hi @bwya77,

first of all - thanks for sharing this styles, it's awesome 👍 

I noticed that "jumping" behaviour and it was bothering me when switching active item in activity bar (check the attached video).

https://github.com/user-attachments/assets/24b51e27-a528-4448-b5e8-3b4431571113

This PR fixes that. 

Regards, Jan 

