### PR TITLE
Update install and uninstall scripts to not remove existing extensions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -62,14 +62,6 @@ if (Test-Path "$extDir\themes") {
     exit 1
 }
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
-if (Test-Path $extJsonPath) {
-    Remove-Item $extJsonPath -Force
-    Write-Host "Cleared extensions.json (VS Code will rebuild it)" -ForegroundColor Green
-}
-
 Write-Host ""
 Write-Host "Step 2: Installing Custom UI Style extension..."
 try {

--- a/install.sh
+++ b/install.sh
@@ -46,14 +46,6 @@ else
     exit 1
 fi
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-EXT_JSON="$HOME/.vscode/extensions/extensions.json"
-if [ -f "$EXT_JSON" ]; then
-    rm -f "$EXT_JSON"
-    echo -e "${GREEN}✓ Cleared extensions.json (VS Code will rebuild it)${NC}"
-fi
-
 echo ""
 echo "🔧 Step 2: Installing Custom UI Style extension..."
 if code --install-extension subframe7536.custom-ui-style --force; then

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -8,6 +8,37 @@ Write-Host "Islands Dark Theme Uninstaller for Windows" -ForegroundColor Cyan
 Write-Host "===========================================" -ForegroundColor Cyan
 Write-Host ""
 
+# Check if VS Code is installed
+$codePath = Get-Command "code" -ErrorAction SilentlyContinue
+if (-not $codePath) {
+    $possiblePaths = @(
+        "$env:LOCALAPPDATA\Programs\Microsoft VS Code\bin\code.cmd",
+        "$env:ProgramFiles\Microsoft VS Code\bin\code.cmd",
+        "${env:ProgramFiles(x86)}\Microsoft VS Code\bin\code.cmd"
+    )
+
+    $found = $false
+    foreach ($path in $possiblePaths) {
+        if (Test-Path $path) {
+            $env:Path += ";$(Split-Path $path)"
+            $found = $true
+            break
+        }
+    }
+
+    if (-not $found) {
+        Write-Host "Error: VS Code CLI (code) not found!" -ForegroundColor Red
+        Write-Host "Please install VS Code and make sure 'code' command is in your PATH."
+        Write-Host "You can do this by:"
+        Write-Host "  1. Open VS Code"
+        Write-Host "  2. Press Ctrl+Shift+P"
+        Write-Host "  3. Type 'Shell Command: Install code command in PATH'"
+        exit 1
+    }
+}
+
+Write-Host "VS Code CLI found" -ForegroundColor Green
+
 # Step 1: Restore old settings
 Write-Host "Step 1: Restoring VS Code settings..."
 $settingsDir = "$env:APPDATA\Code\User"
@@ -42,27 +73,18 @@ if (Test-Path $extDir) {
     Write-Host "Extension directory not found (may already be removed)" -ForegroundColor Yellow
 }
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 Write-Host ""
-Write-Host "Step 4: Unregistering extension..."
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
+Write-Host "Step 4: Uninstalling extension from VS Code..."
 try {
-    if (Test-Path $extJsonPath) {
-        $extensions = Get-Content $extJsonPath -Raw | ConvertFrom-Json
-        $before = $extensions.Count
-        $extensions = @($extensions | Where-Object {
-            $_.identifier.id -ne 'bwya77.islands-dark' -and
-            $_.identifier.id -ne 'your-publisher-name.islands-dark'
-        })
-        if ($extensions.Count -lt $before) {
-            $extensions | ConvertTo-Json -Depth 10 -Compress | Set-Content $extJsonPath
-            Write-Host "Extension unregistered" -ForegroundColor Green
-        } else {
-            Write-Host "Extension was not registered" -ForegroundColor Yellow
-        }
+    $null = code --uninstall-extension bwya77.islands-dark --force 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Extension uninstalled via VS Code CLI" -ForegroundColor Green
+    } else {
+        Write-Host "Extension not installed (or already removed)" -ForegroundColor Yellow
     }
 } catch {
-    Write-Host "Could not update extensions.json" -ForegroundColor Yellow
+    Write-Host "Could not uninstall extension via VS Code CLI" -ForegroundColor Yellow
 }
 
 # Step 5: Change theme

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,6 +12,19 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# Check if code command is available
+if ! command -v code &> /dev/null; then
+    echo -e "${RED}❌ Error: VS Code CLI (code) not found!${NC}"
+    echo "Please install VS Code and make sure 'code' command is in your PATH."
+    echo "You can do this by:"
+    echo "  1. Open VS Code"
+    echo "  2. Press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Linux)"
+    echo "  3. Type 'Shell Command: Install code command in PATH'"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ VS Code CLI found${NC}"
+
 # Step 1: Restore old settings
 echo "⚙️  Step 1: Restoring VS Code settings..."
 SETTINGS_DIR="$HOME/.config/Code/User"
@@ -50,35 +63,13 @@ else
     echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
 fi
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 echo ""
-echo "📋 Step 4: Unregistering extension..."
-if command -v node &> /dev/null; then
-    node << 'UNREGISTER_SCRIPT'
-const fs = require('fs');
-const path = require('path');
-
-const extJsonPath = path.join(process.env.HOME, '.vscode', 'extensions', 'extensions.json');
-if (fs.existsSync(extJsonPath)) {
-    try {
-        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
-        const before = extensions.length;
-        extensions = extensions.filter(e =>
-            e.identifier?.id !== 'bwya77.islands-dark' &&
-            e.identifier?.id !== 'your-publisher-name.islands-dark'
-        );
-        if (extensions.length < before) {
-            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
-            console.log('Extension unregistered');
-        } else {
-            console.log('Extension was not registered');
-        }
-    } catch (e) {
-        console.log('Could not update extensions.json');
-    }
-}
-UNREGISTER_SCRIPT
-    echo -e "${GREEN}✓ Extension unregistered${NC}"
+echo "📋 Step 4: Uninstalling extension from VS Code..."
+if code --uninstall-extension bwya77.islands-dark --force 2>/dev/null; then
+    echo -e "${GREEN}✓ Extension uninstalled via VS Code CLI${NC}"
+else
+    echo -e "${YELLOW}⚠️  Extension not installed (or already removed)${NC}"
 fi
 
 # Step 5: Change theme


### PR DESCRIPTION
Running the install or uninstall scripts looks to be deleting all users existing extensions. In an attempt to prevent that:
- use the vscode cli to install and uninstall extensions instead of parsing and modifying extensions JSON
- do not remove the extensions.json file