### PR TITLE
perf: promote canvas containers to GPU compositor layer

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -114,7 +114,11 @@
       "border-left": "1px solid rgba(255,255,255,0.08) !important",
       "border-bottom": "1px solid rgba(255,255,255,0.03) !important",
       "border-right": "1px solid rgba(255,255,255,0.03) !important",
-      "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+      "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important",
+      "isolation": "isolate",
+      "transform": "translateZ(0)",
+      "will-change": "transform",
+      "contain": "paint"
    },
    ".editor-actions": {
       "padding-right": "20px !important",
@@ -240,7 +244,11 @@
       "border-left": "var(--islands-panel-gap) solid var(--islands-bg-canvas) !important",
       "border-right": "var(--islands-panel-gap) solid var(--islands-bg-canvas) !important",
       "border-bottom": "none !important",
-      "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.1), inset 1px 0 0 0 rgba(255,255,255,0.06), inset -1px 0 0 0 rgba(255,255,255,0.02) !important"
+      "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.1), inset 1px 0 0 0 rgba(255,255,255,0.06), inset -1px 0 0 0 rgba(255,255,255,0.02) !important",
+      "isolation": "isolate",
+      "transform": "translateZ(0)",
+      "will-change": "transform",
+      "contain": "paint"
    },
    ".part.panel.bottom > .composite.title": {
       "position": "relative !important",
@@ -250,7 +258,8 @@
       "margin-top": "-6px !important",
       "position": "relative !important",
       "border-radius": "0 0 calc(var(--islands-panel-radius) - var(--islands-panel-gap)) calc(var(--islands-panel-radius) - var(--islands-panel-gap)) !important",
-      "overflow": "hidden !important"
+      "overflow": "hidden !important",
+      "contain": "paint"
    },
    ".part.panel.bottom .pane": {
       "border-bottom": "none !important"
@@ -274,10 +283,16 @@
       "border-left": "1px solid rgba(255,255,255,0.06) !important",
       "border-radius": "0 0 0 18px !important",
       "box-sizing": "border-box !important",
-      "overflow": "hidden !important"
+      "overflow": "hidden !important",
+      "isolation": "isolate",
+      "transform": "translateZ(0)",
+      "will-change": "transform",
+      "contain": "paint"
    },
    ".part.panel.bottom .terminal.xterm": {
-      "border-radius": "0 0 0 18px !important"
+      "border-radius": "0 0 0 18px !important",
+      "transform": "translateZ(0)",
+      "will-change": "transform"
    },
    ".part.panel.bottom .message-box-container": {
       "border-radius": "10px !important",
@@ -534,7 +549,11 @@
    },
    ".notebookOverlay": {
       "border-radius": "0 0 var(--islands-panel-radius) var(--islands-panel-radius) !important",
-      "clip-path": "inset(0 18px var(--islands-panel-gap) var(--islands-panel-gap) round 0 0 var(--islands-panel-radius) var(--islands-panel-radius)) !important"
+      "clip-path": "inset(0 18px var(--islands-panel-gap) var(--islands-panel-gap) round 0 0 var(--islands-panel-radius) var(--islands-panel-radius)) !important",
+      "isolation": "isolate",
+      "transform": "translateZ(0)",
+      "will-change": "transform",
+      "contain": "paint"
    },
    ".chat-editing-session-container": {
       "border-radius": "var(--islands-input-radius) !important",


### PR DESCRIPTION
## Summary

The `border-radius: var(--islands-panel-radius) !important; overflow: hidden !important;` combo on `.part.editor` and `.part.panel.bottom` causes noticeable lag in the editor and terminal on slower machines. Every time the Monaco editor canvas or the xterm canvas redraws (which is constantly during typing/scrolling), the rasterizer has to re-clip the canvas to the rounded shape on the **CPU compositing path**, because the rounded clip lives on a non-promoted layer.

This PR forces those containers onto their own **GPU compositor layer** so the rounded clip is applied once per frame at composite time, on the GPU, instead of being recomputed every time the canvas redraws.

The fix adds four properties to the canvas containers:

| Property | Why |
|---|---|
| `isolation: isolate` | Creates a new stacking context so `transform` doesn't escape and z-index ordering stays predictable |
| `transform: translateZ(0)` | The classic GPU layer-promotion trigger; makes Chromium allocate a separate composited layer |
| `will-change: transform` | Hints to the engine that this element should be optimized for compositing |
| `contain: paint` | Tells the engine that painting is contained within the element's box, allowing further compositor optimizations |

Affected selectors:

- `.part.editor`
- `.part.panel.bottom`
- `.part.panel.bottom > .content`
- `.part.panel.bottom .terminal-outer-container`
- `.part.panel.bottom .terminal.xterm`
- `.notebookOverlay`

## Visual change

None. The rounded corners, glass borders, shadows and overall look are identical — this is purely a rendering-pipeline optimization.

## Test plan

- [x] Verify `settings.json` is still valid JSON
- [x] Apply on a real Cursor install (3.1.17 / macOS 15) with a heavy workload (5+ tabs, integrated terminal running `npm run dev`, Monaco at scroll) and confirm typing latency / terminal redraw is back to baseline
- [ ] Confirm no visual regression on VS Code (untested by submitter — would appreciate a check on a vanilla VS Code install)
- [ ] Confirm no regression on the Linux selectors (`.monaco-workbench.linux .part.editor > .content` is untouched but the layer promotion on `.part.editor` could interact with it)

## Notes

The same `border-radius + overflow:hidden` pattern exists on the sidebar (`.part.sidebar`, `.part.auxiliarybar`) but those don't lag, because their content is regular DOM rather than `<canvas>` — DOM clipping in rounded corners is essentially free, canvas clipping is not. So I deliberately did not add the GPU promotion there: it would create extra compositor layers for no gain.