### PR TITLE
feat: add Cursor IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ To use it in your NixOS or Home Manager configuration, add it to your flake inpu
 
 > **Note:** The Nix flake automatically includes the **Custom UI Style** extension, **Seti Folder** icon theme, and all required fonts (**Bear Sans UI**, **IBM Plex Mono**, and **FiraCode Nerd Font**). It will also copy the recommended `settings.json` on the first run.
 
+### Cursor (VS Code fork)
+
+Islands Dark works on [Cursor](https://cursor.com/) with two small adaptations baked into a dedicated set of scripts and a `settings-cursor.json` variant.
+
+#### One-Liner Install (Cursor, macOS/Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-cursor.sh | bash
+```
+
+#### Manual Clone Install (Cursor, macOS/Linux)
+
+```bash
+git clone https://github.com/bwya77/vscode-dark-islands.git islands-dark
+cd islands-dark
+./install-cursor.sh
+```
+
+The Cursor installer is a parallel of `install.sh` that targets Cursor-specific paths (`~/.cursor/extensions/`, `~/Library/Application Support/Cursor/User/` on macOS, `~/.config/Cursor/User/` on Linux) and uses the `cursor` CLI instead of `code`. It applies `settings-cursor.json`, which is identical to `settings.json` plus two adjustments required for Cursor:
+
+- `"custom-ui-style.webview.enable": false` — Cursor's extension detail panel renders inside a webview with a stricter Content-Security-Policy than VS Code's; leaving the webview patch enabled triggers a CSP error and a blank panel ([upstream issue](https://github.com/subframe7536/vscode-custom-ui-style#fail-to-render-panel)).
+- A rule hiding `.titlebar-left .action-item:has(.codicon-panel-left)` — Cursor renders a "Toggle Primary Side Bar" button at the top-left of the title bar that overlaps the sidebar's rounded corner. `Cmd+B` continues to toggle the sidebar.
+
+> **Note:** Custom UI Style is not officially supported on Cursor, but works reliably from version `0.5.6` onwards (see [issue #40](https://github.com/subframe7536/vscode-custom-ui-style/issues/40)). After every Cursor update you'll need to re-run **Custom UI Style: Reload** from the command palette to reapply the CSS injection. The "corrupt installation" warning that appears after the first reload is expected and can be dismissed with **Don't Show Again**.
+
+To uninstall:
+
+```bash
+./uninstall-cursor.sh
+```
+
 ### Manual Installation
 
 If you prefer to install manually, follow these steps:
@@ -290,6 +321,13 @@ cd islands-dark
 
 # Or download and run directly:
 irm https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/uninstall.ps1 | iex
+```
+
+**Cursor (macOS/Linux):**
+```bash
+# If you still have the repo cloned:
+cd islands-dark
+./uninstall-cursor.sh
 ```
 
 The uninstall script will:

--- a/bootstrap-cursor.sh
+++ b/bootstrap-cursor.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+# Islands Dark Theme Bootstrap Installer for Cursor
+# One-liner: curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-cursor.sh | bash
+
+echo "🏝️  Islands Dark Theme Bootstrap Installer (Cursor)"
+echo "==================================================="
+echo ""
+
+REPO_URL="https://github.com/bwya77/vscode-dark-islands.git"
+INSTALL_DIR="$HOME/.islands-dark-temp"
+
+# Detect OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    OS="macOS"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    OS="Linux"
+else
+    OS="Linux"
+fi
+
+echo "📥 Step 1: Downloading Islands Dark..."
+echo "   Repository: $REPO_URL"
+
+# Remove old temp directory if exists
+rm -rf "$INSTALL_DIR"
+
+# Clone repository
+BRANCH="main"
+if ! git clone "$REPO_URL" "$INSTALL_DIR" --quiet --branch "$BRANCH"; then
+    echo "❌ Failed to download Islands Dark"
+    exit 1
+fi
+
+echo "✓ Downloaded successfully!"
+echo ""
+
+echo "🚀 Step 2: Running Cursor installer..."
+echo ""
+
+if [[ "$OS" == "macOS" ]] || [[ "$OS" == "Linux" ]]; then
+    cd "$INSTALL_DIR"
+    bash install-cursor.sh
+else
+    echo "⚠️  Automatic installation not supported for this OS"
+    echo "   Please manually run: cd $INSTALL_DIR && ./install-cursor.sh"
+    exit 1
+fi
+
+echo ""
+echo "🧹 Step 3: Cleaning up..."
+read -p "   Remove temporary files? (y/n) " -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    rm -rf "$INSTALL_DIR"
+    echo "✓ Temporary files removed"
+else
+    echo "   Files kept at: $INSTALL_DIR"
+fi
+
+echo ""
+echo -e "🎉 Done! Enjoy your Islands Dark theme on Cursor!"

--- a/install-cursor.sh
+++ b/install-cursor.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -e
+
+
+echo "🏝️  Islands Dark Theme Installer for Cursor (macOS/Linux)"
+echo "========================================================="
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if cursor command is available
+if ! command -v cursor &> /dev/null; then
+    echo -e "${RED}❌ Error: Cursor CLI (cursor) not found!${NC}"
+    echo "Please install Cursor and make sure 'cursor' command is in your PATH."
+    echo "You can do this by:"
+    echo "  1. Open Cursor"
+    echo "  2. Press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Linux)"
+    echo "  3. Type 'Shell Command: Install cursor command in PATH'"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Cursor CLI found${NC}"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo ""
+echo "📦 Step 1: Installing Islands Dark theme extension..."
+
+# Install by copying to Cursor extensions directory
+EXT_DIR="$HOME/.cursor/extensions/bwya77.islands-dark-1.0.0"
+rm -rf "$EXT_DIR"
+mkdir -p "$EXT_DIR"
+cp "$SCRIPT_DIR/package.json" "$EXT_DIR/"
+cp -r "$SCRIPT_DIR/themes" "$EXT_DIR/"
+
+if [ -d "$EXT_DIR/themes" ]; then
+    echo -e "${GREEN}✓ Theme extension installed to $EXT_DIR${NC}"
+else
+    echo -e "${RED}❌ Failed to install theme extension${NC}"
+    exit 1
+fi
+
+# Remove extensions.json so Cursor rebuilds it cleanly on next launch
+EXT_JSON="$HOME/.cursor/extensions/extensions.json"
+if [ -f "$EXT_JSON" ]; then
+    rm -f "$EXT_JSON"
+    echo -e "${GREEN}✓ Cleared extensions.json (Cursor will rebuild it)${NC}"
+fi
+
+echo ""
+echo "🔧 Step 2: Installing Custom UI Style extension..."
+if cursor --install-extension subframe7536.custom-ui-style --force; then
+    echo -e "${GREEN}✓ Custom UI Style extension installed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Could not install Custom UI Style extension automatically${NC}"
+    echo "   Please install it manually from the Extensions marketplace"
+fi
+
+echo ""
+echo "🔤 Step 3: Installing Bear Sans UI fonts..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    FONT_DIR="$HOME/Library/Fonts"
+    echo "   Installing fonts to: $FONT_DIR"
+    cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
+    echo -e "${GREEN}✓ Fonts installed to Font Book${NC}"
+    echo "   Note: You may need to restart applications to use the new fonts"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux
+    FONT_DIR="$HOME/.local/share/fonts"
+    mkdir -p "$FONT_DIR"
+    echo "   Installing fonts to: $FONT_DIR"
+    cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
+    fc-cache -f 2>/dev/null || true
+    echo -e "${GREEN}✓ Fonts installed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Could not detect OS type for automatic font installation${NC}"
+    echo "   Please manually install the fonts from the 'fonts/' folder"
+fi
+
+echo ""
+echo "⚙️  Step 4: Applying Cursor settings..."
+SETTINGS_DIR="$HOME/.config/Cursor/User"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SETTINGS_DIR="$HOME/Library/Application Support/Cursor/User"
+fi
+
+mkdir -p "$SETTINGS_DIR"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+# Backup existing settings if they exist
+if [ -f "$SETTINGS_FILE" ]; then
+    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+    cp "$SETTINGS_FILE" "$BACKUP_FILE"
+    echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
+    echo "   $BACKUP_FILE"
+    echo "   You can restore your old settings from this file if needed."
+fi
+
+# Copy Islands Dark settings (Cursor variant)
+cp "$SCRIPT_DIR/settings-cursor.json" "$SETTINGS_FILE"
+echo -e "${GREEN}✓ Islands Dark settings (Cursor variant) applied${NC}"
+
+echo ""
+echo "🚀 Step 5: Enabling Custom UI Style..."
+echo "   Cursor will reload after applying changes..."
+
+# Create a flag file to indicate first run
+FIRST_RUN_FILE="$SCRIPT_DIR/.islands_dark_cursor_first_run"
+if [ ! -f "$FIRST_RUN_FILE" ]; then
+    touch "$FIRST_RUN_FILE"
+    echo ""
+    echo -e "${YELLOW}📝 Important Notes for Cursor users:${NC}"
+    echo "   • IBM Plex Mono and FiraCode Nerd Font Mono need to be installed separately"
+    echo "   • After Cursor reloads, you may see a 'corrupt installation' warning"
+    echo "   • This is expected — click the gear icon and select 'Don't Show Again'"
+    echo "   • Custom UI Style is not officially supported on Cursor (works since v0.5.6+)"
+    echo "   • The extension's webview patch is disabled to avoid CSP errors on the"
+    echo "     extension detail panel (custom-ui-style.webview.enable is set to false)"
+    echo "   • Cmd+B still toggles the sidebar even though the toggle button is hidden"
+    echo "   • After every Cursor update, re-run 'Custom UI Style: Reload' to reapply"
+    echo ""
+    if [ -t 0 ]; then
+        read -p "Press Enter to continue and reload Cursor..."
+    fi
+fi
+
+echo "   Applying CSS customizations..."
+
+echo -e "${GREEN}✓ Setup complete!${NC}"
+echo ""
+echo "🎉 Islands Dark theme has been installed for Cursor!"
+echo "   Cursor will now reload to apply the custom UI style."
+echo ""
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    osascript -e 'display notification "Islands Dark theme installed for Cursor!" with title "🏝️ Islands Dark"' 2>/dev/null || true
+fi
+
+echo "   Reloading Cursor..."
+cursor --reload-window 2>/dev/null || cursor . 2>/dev/null || true
+
+echo ""
+echo -e "${GREEN}Done! 🏝️${NC}"

--- a/settings-cursor.json
+++ b/settings-cursor.json
@@ -1,0 +1,586 @@
+{
+  "// Islands Dark Settings v0.0.2 — Cursor variant": "",
+  "workbench.colorTheme": "Islands Dark",
+  "editor.fontFamily": "IBM Plex Mono",
+  "terminal.integrated.fontFamily": "FiraCode Nerd Font Mono",
+  "editor.lineHeight": 1.8,
+  "workbench.tree.indent": 16,
+  "workbench.tree.renderIndentGuides": "always",
+  "editor.minimap.showSlider": "always",
+  "// Cursor-specific: disable webview style patching to avoid CSP errors in extension detail panels": "",
+  "custom-ui-style.webview.enable": false,
+  "custom-ui-style.stylesheet": {
+   ".monaco-workbench": {
+      "--islands-panel-radius": "24px",
+      "--islands-widget-radius": "14px",
+      "--islands-input-radius": "12px",
+      "--islands-item-radius": "6px",
+      "--islands-panel-gap": "6px",
+      "--islands-panel-top": "6px",
+      "--islands-bg-canvas": "#121216",
+      "--islands-bg-surface": "#181a1d",
+      "background-color": "var(--islands-bg-canvas) !important"
+   },
+   ".part.sidebar": {
+      "font-family": "'Bear Sans UI', sans-serif !important",
+      "margin": "var(--islands-panel-top) var(--islands-panel-gap) 0 var(--islands-panel-gap)",
+      "border-radius": "var(--islands-panel-radius) !important",
+      "overflow": "hidden !important",
+      "max-height": "calc(100% - 8px) !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.sidebar .composite.title": {
+      "padding": "8px 20px 0 0 !important"
+   },
+   ".part.sidebar .title-label h2": {
+      "font-family": "'Bear Sans UI Heading', sans-serif !important",
+      "font-size": "12px !important",
+      "font-weight": "700 !important",
+      "text-transform": "uppercase !important",
+      "letter-spacing": "1px !important"
+   },
+   ".part.sidebar .content": {
+      "width": "calc(100% - 20px) !important",
+      "padding-left": "10px !important",
+      "margin-left": "6px !important"
+   },
+   ".part.sidebar .welcome-view-content": {
+      "max-width": "100% !important",
+      "box-sizing": "border-box !important"
+   },
+   ".part.sidebar .pane-header": {
+      "border-radius": "var(--islands-item-radius) !important",
+      "outline-offset": "-1px !important"
+   },
+   ".explorer-viewlet .split-view-container": {
+      "margin-top": "-22px !important"
+   },
+   ".part.sidebar .header": {
+      "padding-right": "20px !important"
+   },
+   ".part.sidebar .label-name": {
+      "font-size": "13px !important"
+   },
+   ".part.sidebar .pane-header .title": {
+      "font-size": "10px !important"
+   },
+   ".explorer-folders-view .monaco-tl-row": {
+      "padding-top": "1px !important",
+      "padding-bottom": "1px !important"
+   },
+   ".part.sidebar .monaco-list-row": {
+      "border-radius": "var(--islands-item-radius) !important",
+      "margin-left": "4px !important",
+      "margin-right": "4px !important",
+      "width": "calc(100% - 8px) !important",
+      "transition": "background 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important"
+   },
+   ".part.sidebar .monaco-list-row.selected": {
+      "background": "transparent !important",
+      "box-shadow": "none !important",
+      "outline": "none !important"
+   },
+   ".part.sidebar .monaco-list-row.focused": {
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.6), rgba(37,38,44,0.4)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.05) !important",
+      "outline": "none !important"
+   },
+   ".part.sidebar .monaco-list-row.focused.selected": {
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.7), rgba(37,38,44,0.5)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.07) !important",
+      "outline": "none !important"
+   },
+   ".part.sidebar .monaco-list:focus .monaco-list-row.focused": {
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.8), rgba(37,38,44,0.6)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.08) !important",
+      "outline": "none !important"
+   },
+   ".part.sidebar .monaco-list-row:hover": {
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.3), rgba(37,38,44,0.2)) !important",
+      "border-radius": "var(--islands-item-radius) !important",
+      "outline": "none !important"
+   },
+    ".monaco-workbench.linux .part.editor > .content": {
+      "padding-top": "20px !important"
+   },
+    ".part.editor": {
+      "margin": "var(--islands-panel-top) var(--islands-panel-gap) 0 var(--islands-panel-gap)",
+      "border-radius": "var(--islands-panel-radius) !important",
+      "overflow": "hidden !important",
+      "max-height": "calc(100% - var(--islands-panel-top) - 2px) !important",
+      "border-top": "1px solid rgba(255,255,255,0.12) !important",
+      "border-left": "1px solid rgba(255,255,255,0.08) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.03) !important",
+      "border-right": "1px solid rgba(255,255,255,0.03) !important",
+      "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".editor-actions": {
+      "padding-right": "20px !important",
+      "background-image": "linear-gradient(to top, #25262a 1px, transparent 1px) !important",
+      "background-repeat": "no-repeat !important",
+      "background-position": "bottom !important"
+   },
+   ".tabs-container": {
+      "background-image": "linear-gradient(to top, #25262a 1px, transparent 1px) !important",
+      "background-repeat": "no-repeat !important",
+      "background-position": "bottom !important"
+   },
+   ".tab": {
+      "margin": "0 !important",
+      "border-right": "none !important",
+      "border-radius": "var(--islands-item-radius) var(--islands-item-radius) 0 0 !important",
+      "font-family": "'Bear Sans UI', sans-serif !important",
+      "display": "flex !important",
+      "align-items": "center !important"
+   },
+   ".tab .tab-actions .action-label": {
+      "border-radius": "50% !important"
+   },
+   ".tab.active": {
+      "box-shadow": "inset -1px 0 0 0 #25262a, inset 1px 0 0 0 #25262a !important",
+      "border-right": "none !important"
+   },
+   ".tab:not(.active)": {
+      "box-shadow": "inset 0 -1px 0 0 #25262a !important"
+   },
+   ".tab.active:first-child": {
+      "box-shadow": "inset -1px 0 0 0 #25262a !important"
+   },
+   ".tab:hover .label-name": {
+      "text-shadow": "0 0 5px rgba(255,255,255,0.15) !important",
+      "transition": "text-shadow 0.3s ease !important"
+   },
+   ".minimap canvas": {
+      "opacity": "0.6 !important",
+      "transition": "opacity 0.4s ease !important"
+   },
+   ".minimap:hover canvas": {
+      "opacity": "1 !important"
+   },
+   ".monaco-hover": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "border": "1px solid rgba(255,255,255,0.08) !important",
+      "box-shadow": "0 4px 16px 0 rgba(0,0,0,0.4) !important",
+      "overflow": "hidden !important"
+   },
+   ".monaco-breadcrumbs": {
+      "border-top": "none !important"
+   },
+   ".monaco-breadcrumbs *": {
+      "opacity": "0 !important",
+      "transition": "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)"
+   },
+   ".monaco-breadcrumbs:hover *": {
+      "opacity": "1 !important"
+   },
+   ".split-view-view:has(.terminal-tabs-entry)": {
+      "min-width": "220px !important",
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .tabs-container": {
+      "border-bottom": "none !important",
+      "background-image": "none !important"
+   },
+   ".split-view-view:has(.terminal-tabs-entry) .monaco-list-row": {
+      "border-radius": "var(--islands-item-radius) !important",
+      "margin-right": "20px !important",
+      "width": "calc(100% - 20px) !important"
+   },
+   ".viewpane-filter .monaco-inputbox": {
+      "border-radius": "var(--islands-input-radius) !important"
+   },
+   ".search-widget .monaco-inputbox": {
+      "border-radius": "var(--islands-input-radius) !important"
+   },
+   ".search-widget .replace-input .monaco-findInput": {
+      "width": "228px !important",
+      "height": "26px !important"
+   },
+   ".search-widget .search-container .monaco-findInput": {
+      "width": "228px !important",
+      "height": "26px !important"
+   },
+   ".results.show-file-icons": {
+      "margin-bottom": "22px !important"
+   },
+   ".extensions-search-container": {
+      "transform": "translateX(-6px) !important"
+   },
+   ".extensions-search-container .suggest-input-container": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "overflow": "hidden !important",
+      "font-size": "11px !important",
+      "--editor-font-size": "11px !important"
+   },
+   ".extensions-search-container .suggest-input-placeholder": {
+      "font-size": "11px !important"
+   },
+   ".scm-editor": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".scm-input": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".scm-input + .scm-editor-toolbar + .monaco-button": {
+      "border-radius": "var(--islands-input-radius) !important"
+   },
+   ".part.sidebar .monaco-button": {
+      "border-radius": "var(--islands-input-radius) !important"
+   },
+   ".part.panel.bottom": {
+      "border-radius": "var(--islands-panel-radius)",
+      "overflow": "hidden !important",
+      "box-sizing": "border-box !important",
+      "background-color": "var(--islands-bg-surface) !important",
+      "border-top": "6px solid var(--islands-bg-canvas) !important",
+      "border-left": "var(--islands-panel-gap) solid var(--islands-bg-canvas) !important",
+      "border-right": "var(--islands-panel-gap) solid var(--islands-bg-canvas) !important",
+      "border-bottom": "none !important",
+      "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.1), inset 1px 0 0 0 rgba(255,255,255,0.06), inset -1px 0 0 0 rgba(255,255,255,0.02) !important"
+   },
+   ".part.panel.bottom > .composite.title": {
+      "position": "relative !important",
+      "z-index": "1 !important"
+   },
+   ".part.panel.bottom > .content": {
+      "margin-top": "-6px !important",
+      "position": "relative !important",
+      "border-radius": "0 0 calc(var(--islands-panel-radius) - var(--islands-panel-gap)) calc(var(--islands-panel-radius) - var(--islands-panel-gap)) !important",
+      "overflow": "hidden !important"
+   },
+   ".part.panel.bottom .pane": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .pane-body": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .split-view-view": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .composite": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .monaco-pane-view": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .output-view": {
+      "border-bottom": "none !important"
+   },
+   ".part.panel.bottom .terminal-outer-container": {
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-radius": "0 0 0 18px !important",
+      "box-sizing": "border-box !important",
+      "overflow": "hidden !important"
+   },
+   ".part.panel.bottom .terminal.xterm": {
+      "border-radius": "0 0 0 18px !important"
+   },
+   ".part.panel.bottom .message-box-container": {
+      "border-radius": "10px !important",
+      "margin": "4px !important",
+      "width": "calc(100% - 34px) !important",
+      "box-sizing": "border-box !important"
+   },
+   ".part.panel.bottom .welcome-view-content": {
+      "border-radius": "10px !important",
+      "margin": "4px !important",
+      "width": "calc(100% - 34px) !important",
+      "box-sizing": "border-box !important"
+   },
+   ".part.panel.bottom .monaco-table": {
+      "border-radius": "10px !important",
+      "width": "calc(100% - 14px) !important"
+   },
+    ".part.activitybar": {
+       "background": "var(--islands-bg-canvas) !important",
+       "margin": "8px 0 30px 0",
+      "overflow": "visible !important",
+      "width": "54px !important"
+   },
+   ".part.activitybar .composite-bar": {
+      "background": "color-mix(in srgb, var(--islands-bg-canvas), var(--islands-bg-surface) 30%) !important",
+      "border-radius": "9999px",
+      "overflow": "hidden !important",
+      "width": "calc(100% - 4px) !important",
+      "margin-left": "auto !important",
+      "margin-right": "auto !important",
+      "padding": "8px 3px !important",
+      "box-sizing": "border-box !important",
+      "display": "flex !important",
+      "flex-direction": "column !important",
+      "align-items": "center !important",
+      "border-top": "1px solid rgba(255,255,255,0.12) !important",
+      "border-left": "1px solid rgba(255,255,255,0.08) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.03) !important",
+      "border-right": "1px solid rgba(255,255,255,0.05) !important",
+      "box-shadow": "inset 0 1px 3px 0 rgba(255,255,255,0.06), 0 1px 4px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.activitybar .content > div:last-child": {
+      "transform": "translateY(-10px) !important"
+   },
+   ".part.activitybar .action-item .action-label": {
+      "font-size": "22px !important",
+      "width": "34px !important",
+      "height": "34px !important",
+      "line-height": "34px !important",
+      "display": "flex !important",
+      "align-items": "center !important",
+      "justify-content": "center !important",
+      "overflow": "visible !important"
+   },
+   ".part.activitybar .action-item .action-label .codicon": {
+      "font-size": "22px !important"
+   },
+   ".part.activitybar .action-item .action-label img": {
+      "max-width": "22px !important",
+      "max-height": "22px !important"
+   },
+   ".part.activitybar .action-item .active-item-indicator": {
+      "display": "none !important"
+   },
+   ".part.activitybar .action-item.checked .action-label": {
+      "background": "linear-gradient(180deg, rgba(55,56,62,0.9), rgba(40,41,46,0.7)) !important",
+      "border-radius": "50% !important",
+      "width": "30px !important",
+      "height": "30px !important",
+      "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.12), inset 1px 0 0 0 rgba(255,255,255,0.06), inset 0 -1px 0 0 rgba(255,255,255,0.02), inset -1px 0 0 0 rgba(255,255,255,0.02), inset 0 1px 2px 0 rgba(255,255,255,0.05), 0 1px 3px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.activitybar .actions-container": {
+      "align-items": "center !important",
+      "justify-content": "center !important",
+      "width": "100% !important",
+      "overflow": "visible !important"
+   },
+   ".part.activitybar .action-item": {
+      "display": "flex !important",
+      "justify-content": "center !important",
+      "width": "100% !important",
+      "overflow": "visible !important"
+   },
+   ".part.activitybar .badge": {
+      "z-index": "10 !important",
+      "overflow": "visible !important",
+      "transform": "scale(0.8) !important",
+      "transform-origin": "top right !important"
+   },
+   ".part.titlebar": {
+      "background-color": "var(--islands-bg-canvas) !important"
+   },
+   ".part.statusbar": {
+      "background-color": "var(--islands-bg-canvas) !important",
+      "font-family": "'Bear Sans UI', sans-serif !important"
+   },
+   ".part.statusbar .statusbar-item-label": {
+      "transition": "color 0.4s cubic-bezier(0.4, 0, 0.2, 1)"
+   },
+   ".part.statusbar .codicon": {
+      "transition": "color 0.4s cubic-bezier(0.4, 0, 0.2, 1)"
+   },
+   ".part.statusbar:hover .statusbar-item-label": {
+      "color": "#9a9ea5 !important"
+   },
+   ".part.statusbar:hover .codicon": {
+      "color": "#9a9ea5 !important"
+   },
+   ".part.statusbar .items-container": {
+      "margin-top": "-2px !important"
+   },
+   ".monaco-icon-label.file-icon::before": {
+      "filter": "drop-shadow(0 0 2.5px currentColor)",
+      "opacity": "1 !important"
+   },
+   ".letterpress": {
+      "opacity": "0.4 !important",
+      "filter": "brightness(0) drop-shadow(2px 2px 1px rgba(255,255,255,0.12)) drop-shadow(-2px -2px 1px rgba(0,0,0,1)) !important"
+   },
+   ".part.titlebar .action-label": {
+      "border-radius": "50% !important"
+   },
+   ".command-center-center": {
+      "font-family": "'Bear Sans UI', sans-serif !important",
+      "border-radius": "9999px !important",
+      "overflow": "hidden !important",
+      "border": "none !important",
+      "background": "color-mix(in srgb, var(--islands-bg-canvas), var(--islands-bg-surface) 30%) !important",
+      "box-shadow": "inset 0 1px 0 0 rgba(255,255,255,0.1), inset 1px 0 0 0 rgba(255,255,255,0.05), inset 0 -1px 0 0 rgba(255,255,255,0.02), inset -1px 0 0 0 rgba(255,255,255,0.02), inset 0 1px 3px 0 rgba(255,255,255,0.04), 0 1px 4px 0 rgba(0,0,0,0.25) !important",
+      "transition": "box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important"
+   },
+   ".command-center-center *": {
+      "border-radius": "9999px !important"
+   },
+   ".notifications-toasts": {
+      "margin-right": "var(--islands-panel-gap) !important",
+      "margin-bottom": "var(--islands-panel-gap) !important"
+   },
+   ".notification-toast": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 4px 12px 0 rgba(0,0,0,0.4) !important"
+   },
+   ".notifications-center": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 4px 12px 0 rgba(0,0,0,0.4) !important"
+   },
+   ".notification-list-item-actions-container": {
+      "border-radius": "var(--islands-item-radius) !important"
+   },
+   ".notification-list-item": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".notification-list-item.focused": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "outline-offset": "-1px !important"
+   },
+   ".monaco-list-row:has(.notification-list-item)": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".part.auxiliarybar": {
+      "margin": "var(--islands-panel-top) var(--islands-panel-gap) 0 var(--islands-panel-gap)",
+      "border-radius": "var(--islands-panel-radius) !important",
+      "overflow": "hidden !important",
+      "max-height": "calc(100% - var(--islands-panel-top) - 2px) !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.auxiliarybar .composite.title": {
+      "padding": "8px 0 0 8px !important"
+   },
+   ".part.auxiliarybar .content": {
+      "width": "100% !important"
+   },
+   ".part.auxiliarybar .split-view-view": {
+      "max-height": "calc(100% - 24px) !important"
+   },
+   ".part.auxiliarybar .header": {
+      "padding-left": "8px !important"
+   },
+   ".quick-input-widget": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 8px 24px 0 rgba(0,0,0,0.5) !important"
+   },
+   ".quick-input-widget .monaco-list-row": {
+      "border-radius": "var(--islands-item-radius) !important",
+      "margin-left": "4px !important",
+      "margin-right": "4px !important",
+      "width": "calc(100% - 8px) !important",
+      "transition": "background 0.15s cubic-bezier(0.4, 0, 0.2, 1) !important"
+   },
+   ".quick-input-widget .monaco-list-row.focused": {
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.7), rgba(37,38,44,0.5)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.06) !important"
+   },
+   ".scrollbar .slider": {
+      "border-radius": "9999px !important",
+      "transition": "opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important"
+   },
+   ".monaco-count-badge": {
+      "border-radius": "9999px !important",
+      "font-size": "12px !important",
+      "padding": "0 6px !important",
+      "min-height": "16px !important",
+      "line-height": "16px !important",
+      "transform": "scale(0.85) !important"
+   },
+   ".tab .tab-actions": {
+      "opacity": "0 !important",
+      "transition": "opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important"
+   },
+   ".tab:hover .tab-actions": {
+      "opacity": "1 !important"
+   },
+   ".tab.active .tab-actions": {
+      "opacity": "1 !important"
+   },
+   ".sticky-widget": {
+      "box-shadow": "0 4px 8px -2px rgba(0,0,0,0.4) !important"
+   },
+   ".monaco-dialog-box": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "box-shadow": "0 8px 24px 0 rgba(0,0,0,0.5) !important"
+   },
+   ".monaco-dialog-box .dialog-buttons .monaco-button": {
+      "border-radius": "var(--islands-input-radius) !important"
+   },
+   ".notebook-toolbar-container": {
+      "max-width": "calc(100% - 18px) !important"
+   },
+   ".notebookOverlay": {
+      "border-radius": "0 0 var(--islands-panel-radius) var(--islands-panel-radius) !important",
+      "clip-path": "inset(0 18px var(--islands-panel-gap) var(--islands-panel-gap) round 0 0 var(--islands-panel-radius) var(--islands-panel-radius)) !important"
+   },
+   ".chat-editing-session-container": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".chat-confirmation-widget2": {
+      "border-radius": "var(--islands-input-radius) !important",
+      "overflow": "hidden !important"
+   },
+   ".chat-input-container": {
+      "background-color": "var(--islands-bg-surface) !important",
+      "border-radius": "var(--islands-widget-radius) !important",
+      "border-top": "1px solid rgba(255,255,255,0.1) !important",
+      "border-left": "1px solid rgba(255,255,255,0.06) !important",
+      "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
+      "border-right": "1px solid rgba(255,255,255,0.02) !important",
+      "overflow": "hidden !important"
+   },
+   ".chat-input-container .monaco-inputbox": {
+      "background-color": "var(--islands-bg-surface) !important"
+   },
+   ".interactive-input-part": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "hidden !important"
+   },
+
+   ".monaco-button-dropdown-separator": {
+      "display": "none !important",
+      "background": "transparent !important",
+      "background-color": "transparent !important",
+      "width": "0 !important",
+      "opacity": "0 !important"
+   },
+
+   "// ─── Cursor-specific overrides ───": "",
+   ".titlebar-left .action-item:has(.codicon-panel-left)": {
+      "display": "none !important"
+   },
+   ".titlebar-left .action-item:has(.codicon-panel-left-off)": {
+      "display": "none !important"
+   },
+
+   "// ─── end ───": ""
+  },
+"workbench.iconTheme": "vs-seti-folder",
+"chat.viewSessions.orientation": "stacked"
+}

--- a/uninstall-cursor.sh
+++ b/uninstall-cursor.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e
+
+echo "🏝️  Islands Dark Theme Uninstaller for Cursor (macOS/Linux)"
+echo "==========================================================="
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Step 1: Restore old settings
+echo "⚙️  Step 1: Restoring Cursor settings..."
+SETTINGS_DIR="$HOME/.config/Cursor/User"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SETTINGS_DIR="$HOME/Library/Application Support/Cursor/User"
+fi
+
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+
+if [ -f "$BACKUP_FILE" ]; then
+    cp "$BACKUP_FILE" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Settings restored from backup${NC}"
+    echo "   Backup file: $BACKUP_FILE"
+else
+    echo -e "${YELLOW}⚠️  No backup found at $BACKUP_FILE${NC}"
+    echo "   You may need to manually update your Cursor settings."
+fi
+
+# Step 2: Disable Custom UI Style
+echo ""
+echo "🔧 Step 2: Disabling Custom UI Style..."
+echo -e "${YELLOW}   Please disable Custom UI Style manually:${NC}"
+echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
+echo "   2. Run 'Custom UI Style: Disable'"
+echo "   3. Cursor will reload"
+
+# Step 3: Remove theme extension
+echo ""
+echo "🗑️  Step 3: Removing Islands Dark theme extension..."
+EXT_DIR="$HOME/.cursor/extensions/bwya77.islands-dark-1.0.0"
+if [ -d "$EXT_DIR" ] || [ -L "$EXT_DIR" ]; then
+    rm -rf "$EXT_DIR"
+    echo -e "${GREEN}✓ Theme extension removed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
+fi
+
+# Step 4: Remove extension from extensions.json
+echo ""
+echo "📋 Step 4: Unregistering extension..."
+if command -v node &> /dev/null; then
+    node << 'UNREGISTER_SCRIPT'
+const fs = require('fs');
+const path = require('path');
+
+const extJsonPath = path.join(process.env.HOME, '.cursor', 'extensions', 'extensions.json');
+if (fs.existsSync(extJsonPath)) {
+    try {
+        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
+        const before = extensions.length;
+        extensions = extensions.filter(e =>
+            e.identifier?.id !== 'bwya77.islands-dark' &&
+            e.identifier?.id !== 'your-publisher-name.islands-dark'
+        );
+        if (extensions.length < before) {
+            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
+            console.log('Extension unregistered');
+        } else {
+            console.log('Extension was not registered');
+        }
+    } catch (e) {
+        console.log('Could not update extensions.json');
+    }
+}
+UNREGISTER_SCRIPT
+    echo -e "${GREEN}✓ Extension unregistered${NC}"
+fi
+
+# Step 5: Change theme
+echo ""
+echo "🎨 Step 5: Change your color theme..."
+echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
+echo "   2. Search for 'Preferences: Color Theme'"
+echo "   3. Select your preferred theme"
+
+echo ""
+echo -e "${GREEN}✓ Islands Dark has been uninstalled from Cursor!${NC}"
+echo ""
+echo "   Reload Cursor to complete the process."
+echo ""


### PR DESCRIPTION
## Summary

[Cursor](https://cursor.com) is a popular VS Code fork. The current `install.sh` / `bootstrap.sh` / `uninstall.sh` target VS Code paths and the `code` CLI, so Cursor users can't use the one-liner. This PR adds a parallel install flow for Cursor without touching anything VS Code uses.

Once merged, Cursor users get the same one-line install experience:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-cursor.sh | bash
\`\`\`

## What's added

| File | Purpose |
|---|---|
| `install-cursor.sh` | Mirror of `install.sh` for Cursor — uses `~/.cursor/extensions/`, `~/Library/Application Support/Cursor/User/` (or `~/.config/Cursor/User/` on Linux), and the `cursor` CLI |
| `bootstrap-cursor.sh` | One-liner entry point — clones the repo and runs `install-cursor.sh` |
| `uninstall-cursor.sh` | Mirror of `uninstall.sh` for Cursor paths |
| `settings-cursor.json` | Identical to `settings.json` plus two Cursor-specific tweaks (see below) |
| `README.md` | New "Cursor (VS Code fork)" subsection under Installation, plus a Cursor block under Uninstalling |

## The two Cursor-specific tweaks in `settings-cursor.json`

1. **`\"custom-ui-style.webview.enable\": false`** — Cursor's extension detail panel renders inside a webview with a stricter Content-Security-Policy than VS Code's. Leaving the webview patch enabled triggers a CSP error and a blank panel ([upstream issue](https://github.com/subframe7536/vscode-custom-ui-style#fail-to-render-panel)).

2. **Hide the layout-toggle button** — Cursor renders a "Toggle Primary Side Bar" action item at the top-left of the title bar (`<a class=\"action-label codicon codicon-panel-left\" aria-label=\"Toggle Primary Side Bar (⌘B)\">`). With Islands Dark's rounded sidebar corners, this button visually overlaps the rounded corner of `.part.sidebar`. Hiding it via:
   \`\`\`css
   .titlebar-left .action-item:has(.codicon-panel-left),
   .titlebar-left .action-item:has(.codicon-panel-left-off) {
     display: none !important;
   }
   \`\`\`
   ⌘B continues to toggle the sidebar normally.

## Compatibility note in the README

Custom UI Style is officially \"untested on VS Code forks\" by its author, but works reliably on Cursor since v0.5.6 (see [subframe7536/vscode-custom-ui-style#40](https://github.com/subframe7536/vscode-custom-ui-style/issues/40)). The README documents:

- The expected \"corrupt installation\" warning after the first `Custom UI Style: Reload`
- The fact that **after every Cursor update**, users need to re-run `Custom UI Style: Reload` to reapply the CSS injection (Cursor self-heals its `workbench.html` on update, undoing the patch)

## Why a separate `settings-cursor.json` vs runtime patching

I chose to ship a complete settings file rather than have `install-cursor.sh` patch `settings.json` at install time. Reasons:

1. Mirrors how `install.sh` works — a flat `cp` of a settings file. No new runtime logic to review.
2. The Cursor-specific bits are clearly visible to anyone reading the file (with `// Cursor-specific: ...` JSON-string comments).
3. If you ever change `settings.json`, regenerating `settings-cursor.json` is a 30-second job (`cp` + add the two tweaks). Happy to add a sync script or convert to a runtime-patch approach if you'd rather have a single source of truth — let me know your preference and I'll update.

## Why this doesn't depend on the perf PR

I have a separate PR (#126) that adds GPU layer promotion to canvas containers, fixing editor/terminal lag. It's beneficial to **all** users (VS Code and Cursor), not just Cursor, so I kept it independent. This Cursor PR rebases cleanly on top of that one — `settings-cursor.json` will pick up the perf fix automatically once both are merged and someone regenerates the file.

## Test plan

- [x] `bash install-cursor.sh` on Cursor 3.1.17 / macOS 15 — extension installed, fonts copied, settings applied, Custom UI Style reloads, theme renders
- [x] `bash uninstall-cursor.sh` restores the backed-up `settings.json.pre-islands-dark`
- [x] All shell scripts pass `bash -n` (syntax check) and `shellcheck` clean
- [x] `settings-cursor.json` is valid JSON (`node -e \"JSON.parse(require('fs').readFileSync('settings-cursor.json'))\"`)
- [ ] Linux test — submitter only tested on macOS. The Linux paths (`~/.config/Cursor/User/`) are mirrored from the existing `install.sh` Linux logic, but a real Linux test would be appreciated
- [ ] PowerShell variant for Windows Cursor users — not included in this PR. Happy to add `install-cursor.ps1` / `bootstrap-cursor.ps1` / `uninstall-cursor.ps1` in a follow-up if you'd accept it (untested by me — no Windows machine available)