### PR TITLE
Refactor bootstrap script

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -5,7 +5,7 @@ param()
 
 $ErrorActionPreference = "Stop"
 
-echo "🏝️  Islands Dark Theme Bootstrap Installer"
+echo '🏝️  Islands Dark Theme Bootstrap Installer'
 echo "=========================================="
 echo ""
 
@@ -14,7 +14,7 @@ $Branch = "main"
 $TempRoot = if ([string]::IsNullOrWhiteSpace($env:TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:TEMP }
 $InstallDir = Join-Path $TempRoot ("islands-dark-temp-{0}" -f ([guid]::NewGuid().ToString("N")))
 
-echo "📥 Step 1: Downloading Islands Dark..."
+echo '📥 Step 1: Downloading Islands Dark...'
 echo "   Repository: $RepoUrl"
 
 # Remove old temp directory if exists
@@ -30,16 +30,16 @@ try {
         throw "git clone exited with code $LASTEXITCODE"
     }
 } catch {
-    echo "❌ Failed to download Islands Dark"
+    echo '❌ Failed to download Islands Dark'
     echo "   Make sure Git is installed: https://git-scm.com/download/win"
     echo "   $($_.Exception.Message)"
     return
 }
 
-echo "✓ Downloaded successfully"
+echo '✓ Downloaded successfully'
 echo ""
 
-echo "🚀 Step 2: Running installer..."
+echo '🚀 Step 2: Running installer...'
 echo ""
 
 # Run installer
@@ -62,7 +62,7 @@ try {
 
 # Cleanup
 echo ""
-echo "🧹 Step 3: Cleaning up..."
+echo '🧹 Step 3: Cleaning up...'
 $remove = Read-Host "   Remove temporary files? (y/n)"
 if ($remove -eq 'y' -or $remove -eq 'Y') {
     try {
@@ -78,4 +78,4 @@ if ($remove -eq 'y' -or $remove -eq 'Y') {
 }
 
 echo ""
-echo "🎉 Done! Enjoy your Islands Dark theme!"
+echo '🎉 Done! Enjoy your Islands Dark theme!'

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -11,23 +11,29 @@ echo ""
 
 $RepoUrl = "https://github.com/bwya77/vscode-dark-islands.git"
 $Branch = "main"
-$InstallDir = "$env:TEMP\islands-dark-temp"
+$TempRoot = if ([string]::IsNullOrWhiteSpace($env:TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:TEMP }
+$InstallDir = Join-Path $TempRoot ("islands-dark-temp-{0}" -f ([guid]::NewGuid().ToString("N")))
 
 echo "📥 Step 1: Downloading Islands Dark..."
 echo "   Repository: $RepoUrl"
 
 # Remove old temp directory if exists
-if (Test-Path $InstallDir) {
-    Remove-Item -Recurse -Force $InstallDir
+if (Test-Path -LiteralPath $InstallDir) {
+    Remove-Item -LiteralPath $InstallDir -Recurse -Force
 }
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 
 # Clone repository
 try {
     git clone $RepoUrl $InstallDir --quiet --branch $Branch
+    if ($LASTEXITCODE -ne 0) {
+        throw "git clone exited with code $LASTEXITCODE"
+    }
 } catch {
     echo "❌ Failed to download Islands Dark"
     echo "   Make sure Git is installed: https://git-scm.com/download/win"
-    exit 1
+    echo "   $($_.Exception.Message)"
+    return
 }
 
 echo "✓ Downloaded successfully"
@@ -37,13 +43,21 @@ echo "🚀 Step 2: Running installer..."
 echo ""
 
 # Run installer
-cd $InstallDir
+$InstallerPath = Join-Path $InstallDir "install.ps1"
+$PowerShellPath = (Get-Command "powershell.exe" -ErrorAction SilentlyContinue).Source
+if (-not $PowerShellPath) {
+    $PowerShellPath = (Get-Process -Id $PID).Path
+}
+
 try {
-    .\install.ps1
+    & $PowerShellPath -NoProfile -ExecutionPolicy Bypass -File $InstallerPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "Installer exited with code $LASTEXITCODE"
+    }
 } catch {
     echo "❌ Installation failed"
     echo $_.Exception.Message
-    exit 1
+    return
 }
 
 # Cleanup
@@ -51,8 +65,14 @@ echo ""
 echo "🧹 Step 3: Cleaning up..."
 $remove = Read-Host "   Remove temporary files? (y/n)"
 if ($remove -eq 'y' -or $remove -eq 'Y') {
-    Remove-Item -Recurse -Force $InstallDir
-    echo "✓ Temporary files removed"
+    try {
+        Remove-Item -LiteralPath $InstallDir -Recurse -Force
+        echo '✓ Temporary files removed'
+    } catch {
+        echo "   Could not remove temporary files:"
+        echo "   $($_.Exception.Message)"
+        echo "   Files kept at: $InstallDir"
+    }
 } else {
     echo "   Files kept at: $InstallDir"
 }


### PR DESCRIPTION
## Summary

This PR hardens `bootstrap.ps1` so the Windows bootstrap installer handles common failure cases more reliably.

## Issues

- `$InstallDir` was assumed to exist or be created by `git clone`.
- `git clone` failures were not reliably caught because native command failures do not always trigger `try/catch` in Windows PowerShell.
- The script changed into `$InstallDir`, which could prevent cleanup from deleting the temp folder on Windows.
- `exit 1` could close the user’s current PowerShell session when run through `irm ... | iex`.
- Running `install.ps1` directly could be affected by PowerShell execution policy.
- Cleanup errors could make an otherwise successful install appear failed.

## Fixes

- Creates a unique temp install directory before cloning.
- Checks `$LASTEXITCODE` after `git clone` and the installer process.
- Runs `install.ps1` through a child PowerShell process with `-ExecutionPolicy Bypass`.
- Uses `return` instead of `exit 1` in bootstrap failure paths.
- Avoids changing into the temp directory before running the installer.
- Wraps temp cleanup in `try/catch` and reports when files are kept.
- Normalised emoji `echo` strings to use regular quotes, avoiding issues from copied smart/backwards quotes.