### PR TITLE
fix(install.ps1): preserve user settings.json instead of overwriting

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -116,18 +116,68 @@ if (-not (Test-Path $settingsDir)) {
 
 $settingsFile = Join-Path $settingsDir "settings.json"
 
-# Backup existing settings if they exist
+# Strip JSONC features (comments, trailing commas) so ConvertFrom-Json can parse
+function Strip-Jsonc {
+    param([string]$Text)
+    $Text = $Text -replace '//.*$', ''
+    $Text = $Text -replace '/\*[\s\S]*?\*/', ''
+    $Text = $Text -replace ',\s*([}\]])', '$1'
+    return $Text
+}
+
+$newSettingsRaw = Get-Content "$scriptDir\settings.json" -Raw
+$newSettings = (Strip-Jsonc $newSettingsRaw) | ConvertFrom-Json
+
+# If the user has existing settings, merge instead of overwrite. Existing keys
+# WIN on conflict so personal choices (fontFamily, lineHeight, etc.) are preserved.
+# Users who want the full Islands look can manually remove their conflicting keys.
 if (Test-Path $settingsFile) {
     $backupFile = "$settingsFile.pre-islands-dark"
     Copy-Item $settingsFile $backupFile -Force
     Write-Host "Existing settings.json backed up to:" -ForegroundColor Yellow
     Write-Host "   $backupFile"
     Write-Host "   You can restore your old settings from this file if needed."
-}
 
-# Copy Islands Dark settings
-Copy-Item "$scriptDir\settings.json" $settingsFile -Force
-Write-Host "Islands Dark settings applied" -ForegroundColor Green
+    try {
+        $existingRaw = Get-Content $settingsFile -Raw
+        $existingSettings = (Strip-Jsonc $existingRaw) | ConvertFrom-Json
+
+        # Start with Islands defaults, then layer existing user settings on top so
+        # the user's choices override Islands' choices on any conflicting key.
+        $mergedSettings = [ordered]@{}
+        $newSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+        $existingSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+
+        # Deep merge custom-ui-style.stylesheet so any per-user CSS tweaks survive
+        $stylesheetKey = 'custom-ui-style.stylesheet'
+        if ($existingSettings.$stylesheetKey -and $newSettings.$stylesheetKey) {
+            $mergedStylesheet = [ordered]@{}
+            $newSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            $existingSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            $mergedSettings[$stylesheetKey] = [PSCustomObject]$mergedStylesheet
+        }
+
+        [PSCustomObject]$mergedSettings | ConvertTo-Json -Depth 100 | Set-Content $settingsFile
+        Write-Host "Settings merged (your existing keys preserved)" -ForegroundColor Green
+        Write-Host "   Note: JSONC comments are stripped during merge - your backup retains them" -ForegroundColor DarkGray
+        Write-Host "   To apply Islands' font/spacing defaults, remove the matching keys from your settings.json" -ForegroundColor DarkGray
+    } catch {
+        Write-Host "Could not parse existing settings.json - leaving it untouched" -ForegroundColor Yellow
+        Write-Host "   To get the Islands Dark settings, manually copy from $scriptDir\settings.json"
+        Write-Host "   Error: $($_.Exception.Message)" -ForegroundColor DarkGray
+    }
+} else {
+    Copy-Item "$scriptDir\settings.json" $settingsFile -Force
+    Write-Host "Islands Dark settings applied" -ForegroundColor Green
+}
 
 Write-Host ""
 Write-Host "Step 5: Enabling Custom UI Style..."


### PR DESCRIPTION
## Summary

`install.ps1` currently `Copy-Item -Force`s the bundled `settings.json` over the user's file, wiping unrelated keys (font, linters, theme, etc.). This PR deep-merges instead, with user keys winning on conflict. The `.pre-islands-dark` backup is still created.

The merge logic is lifted from `install-antigravity.ps1` (already in this repo), so the approach is precedented. Only the conflict-resolution direction differs.

Addresses #86, #111, #128 (and the settings half of #102).

## Behavior

| User has | Before | After |
|----------|--------|-------|
| Custom `editor.fontFamily`, `python.*`, theme, etc. | Overwritten | Preserved |
| `custom-ui-style.stylesheet` tweaks | Wiped | Deep-merged, user wins |
| Unparseable JSONC | Overwritten anyway | Left untouched |
| No existing file | Bundled copied | Unchanged |

## Known limitation

JSONC comments in the user's file get stripped (PowerShell can't roundtrip them). Backup preserves them verbatim. Proper fix needs a real JSONC parser, which is out of scope.

## Out of scope

`install.sh`, `extensions.json` (#119), README warning (#132), replacing `custom-ui-style` (#123).

## Test plan

- [x] Bundled `settings.json` parses through Strip-Jsonc + ConvertFrom-Json
- [x] Synthetic merge preserves user keys, adds Islands keys
- [ ] (reviewer) Run on VS Code with customized `settings.json`
- [ ] (reviewer) Run on VS Code with no `settings.json`