### PR TITLE
fix: explorer multi-select visibility, hidden items, install script safety, and copilot sidebar layout

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -62,13 +62,6 @@ if (Test-Path "$extDir\themes") {
     exit 1
 }
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
-if (Test-Path $extJsonPath) {
-    Remove-Item $extJsonPath -Force
-    Write-Host "Cleared extensions.json (VS Code will rebuild it)" -ForegroundColor Green
-}
 
 Write-Host ""
 Write-Host "Step 2: Installing Custom UI Style extension..."
@@ -116,18 +109,78 @@ if (-not (Test-Path $settingsDir)) {
 
 $settingsFile = Join-Path $settingsDir "settings.json"
 
-# Backup existing settings if they exist
+# Strip JSONC features (comments, trailing commas) so ConvertFrom-Json can parse
+function Strip-Jsonc {
+    param([string]$Text)
+    # Remove single-line comments
+    $Text = $Text -replace '(?m)//.*$', ''
+    # Remove multi-line comments
+    $Text = $Text -replace '/\*[\s\S]*?\*/', ''
+    # Remove trailing commas before } or ]
+    $Text = $Text -replace ',\s*([}\]])', '$1'
+    return $Text
+}
+
+$newSettingsRaw = Get-Content "$scriptDir\settings.json" -Raw
+$newSettings = (Strip-Jsonc $newSettingsRaw) | ConvertFrom-Json
+
+# If the user has existing settings, merge instead of overwrite.
+# Islands Dark theme keys win so updated fixes are applied correctly.
+# Non-theme user settings are preserved.
 if (Test-Path $settingsFile) {
-    $backupFile = "$settingsFile.pre-islands-dark"
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $backupFile = "$settingsFile.pre-islands-dark.$timestamp"
     Copy-Item $settingsFile $backupFile -Force
     Write-Host "Existing settings.json backed up to:" -ForegroundColor Yellow
     Write-Host "   $backupFile"
     Write-Host "   You can restore your old settings from this file if needed."
-}
 
-# Copy Islands Dark settings
-Copy-Item "$scriptDir\settings.json" $settingsFile -Force
-Write-Host "Islands Dark settings applied" -ForegroundColor Green
+    try {
+        $existingRaw = Get-Content $settingsFile -Raw
+        $existingSettings = (Strip-Jsonc $existingRaw) | ConvertFrom-Json
+
+        # Start with user's existing settings, then overlay Islands Dark theme settings.
+        # Theme keys win so fixes/updates are applied correctly.
+        $mergedSettings = [ordered]@{}
+
+        # First, copy all existing user settings
+        $existingSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+
+        # Then overlay Islands Dark settings (theme keys win)
+        $newSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+
+        # Deep merge custom-ui-style.stylesheet so user's extra CSS rules survive
+        # but Islands Dark's selectors always get the latest fixes
+        $stylesheetKey = 'custom-ui-style.stylesheet'
+        if ($existingSettings.$stylesheetKey -and $newSettings.$stylesheetKey) {
+            $mergedStylesheet = [ordered]@{}
+            # Start with user's custom CSS selectors
+            $existingSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            # Overlay Islands Dark selectors (theme wins for its own selectors)
+            $newSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            $mergedSettings[$stylesheetKey] = [PSCustomObject]$mergedStylesheet
+        }
+
+        [PSCustomObject]$mergedSettings | ConvertTo-Json -Depth 100 | Set-Content $settingsFile
+        Write-Host "Settings merged (your non-theme settings preserved, theme settings updated)" -ForegroundColor Green
+    } catch {
+        Write-Host "Could not parse existing settings.json - leaving it untouched" -ForegroundColor Yellow
+        Write-Host "   Your backup is at: $backupFile" -ForegroundColor DarkGray
+        Write-Host "   To apply Islands Dark settings, manually merge from: $scriptDir\settings.json" -ForegroundColor DarkGray
+        Write-Host "   Error: $($_.Exception.Message)" -ForegroundColor DarkGray
+    }
+} else {
+    Copy-Item "$scriptDir\settings.json" $settingsFile -Force
+    Write-Host "Islands Dark settings applied" -ForegroundColor Green
+}
 
 Write-Host ""
 Write-Host "Step 5: Enabling Custom UI Style..."

--- a/install.sh
+++ b/install.sh
@@ -46,14 +46,6 @@ else
     exit 1
 fi
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-EXT_JSON="$HOME/.vscode/extensions/extensions.json"
-if [ -f "$EXT_JSON" ]; then
-    rm -f "$EXT_JSON"
-    echo -e "${GREEN}✓ Cleared extensions.json (VS Code will rebuild it)${NC}"
-fi
-
 echo ""
 echo "🔧 Step 2: Installing Custom UI Style extension..."
 if code --install-extension subframe7536.custom-ui-style --force; then
@@ -95,18 +87,37 @@ fi
 mkdir -p "$SETTINGS_DIR"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
-# Backup existing settings if they exist
+# Backup existing settings if they exist, then merge
 if [ -f "$SETTINGS_FILE" ]; then
-    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+    TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark.$TIMESTAMP"
     cp "$SETTINGS_FILE" "$BACKUP_FILE"
     echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
     echo "   $BACKUP_FILE"
     echo "   You can restore your old settings from this file if needed."
-fi
 
-# Copy Islands Dark settings
-cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
-echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+    if command -v jq &> /dev/null; then
+        # Merge: user's non-theme settings are preserved, Islands Dark theme keys win
+        # This ensures updated fixes are applied while keeping user customizations
+        if MERGED=$(jq -s '.[0] * .[1]' "$SETTINGS_FILE" "$SCRIPT_DIR/settings.json" 2>/dev/null); then
+            echo "$MERGED" > "$SETTINGS_FILE"
+            echo -e "${GREEN}✓ Settings merged (your non-theme settings preserved, theme settings updated)${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Could not parse existing settings.json - leaving it untouched${NC}"
+            echo "   Your backup is at: $BACKUP_FILE"
+            echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        fi
+    else
+        echo -e "${YELLOW}⚠️  jq not found - cannot merge settings safely${NC}"
+        echo "   Your backup is at: $BACKUP_FILE"
+        echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        echo "   Or install jq (https://jqlang.github.io/jq/) and re-run this script"
+    fi
+else
+    # No existing settings - just copy
+    cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+fi
 
 echo ""
 echo "🚀 Step 5: Enabling Custom UI Style..."

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-  "// Islands Dark Settings v0.0.2": "",
+  "// Islands Dark Settings v0.0.3": "",
   "workbench.colorTheme": "Islands Dark",
   "editor.fontFamily": "IBM Plex Mono",
   "terminal.integrated.fontFamily": "FiraCode Nerd Font Mono",
@@ -55,7 +55,7 @@
       "outline-offset": "-1px !important"
    },
    ".explorer-viewlet .split-view-container": {
-      "margin-top": "-22px !important"
+      "margin-top": "0 !important"
    },
    ".part.sidebar .header": {
       "padding-right": "20px !important"
@@ -78,8 +78,8 @@
       "transition": "background 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important"
    },
    ".part.sidebar .monaco-list-row.selected": {
-      "background": "transparent !important",
-      "box-shadow": "none !important",
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.35), rgba(37,38,44,0.25)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.04) !important",
       "outline": "none !important"
    },
    ".part.sidebar .monaco-list-row.focused": {
@@ -115,6 +115,9 @@
       "border-bottom": "1px solid rgba(255,255,255,0.03) !important",
       "border-right": "1px solid rgba(255,255,255,0.03) !important",
       "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.editor > .modal-editor-header": {
+      "height": "60px !important"
    },
    ".editor-actions": {
       "padding-right": "20px !important",
@@ -247,10 +250,13 @@
       "z-index": "1 !important"
    },
    ".part.panel.bottom > .content": {
-      "margin-top": "-6px !important",
+      "margin-top": "0 !important",
       "position": "relative !important",
       "border-radius": "0 0 calc(var(--islands-panel-radius) - var(--islands-panel-gap)) calc(var(--islands-panel-radius) - var(--islands-panel-gap)) !important",
       "overflow": "hidden !important"
+   },
+   ".part.panel.bottom:has(.terminal-outer-container) > .content": {
+      "margin-top": "-7px !important"
    },
    ".part.panel.bottom .pane": {
       "border-bottom": "none !important"
@@ -467,10 +473,42 @@
       "width": "100% !important"
    },
    ".part.auxiliarybar .split-view-view": {
-      "max-height": "calc(100% - 24px) !important"
+      "max-height": "100% !important",
+      "overflow": "hidden !important",
+      "display": "flex !important",
+      "flex-direction": "column !important"
    },
    ".part.auxiliarybar .header": {
       "padding-left": "8px !important"
+   },
+   ".part.auxiliarybar .chat-input-part": {
+      "position": "sticky !important",
+      "bottom": "0 !important",
+      "z-index": "10 !important"
+   },
+   ".part.auxiliarybar .interactive-input-part": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "visible !important",
+      "flex-shrink": "0 !important"
+   },
+   ".part.auxiliarybar .interactive-session": {
+      "display": "flex !important",
+      "flex-direction": "column !important",
+      "height": "100% !important",
+      "overflow": "hidden !important"
+   },
+   ".part.auxiliarybar .interactive-list": {
+      "flex": "1 1 auto !important",
+      "overflow-y": "auto !important",
+      "min-height": "0 !important"
+   },
+   ".part.auxiliarybar .chat-input-container": {
+      "flex-shrink": "0 !important",
+      "overflow": "visible !important",
+      "min-height": "fit-content !important"
+   },
+   ".part.auxiliarybar .monaco-inputbox": {
+      "overflow": "visible !important"
    },
    ".quick-input-widget": {
       "border-radius": "var(--islands-widget-radius) !important",
@@ -551,14 +589,22 @@
       "border-left": "1px solid rgba(255,255,255,0.06) !important",
       "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
       "border-right": "1px solid rgba(255,255,255,0.02) !important",
-      "overflow": "hidden !important"
+      "overflow": "visible !important",
+      "display": "flex !important",
+      "flex-direction": "column !important",
+      "align-items": "stretch !important"
    },
    ".chat-input-container .monaco-inputbox": {
       "background-color": "var(--islands-bg-surface) !important"
    },
    ".interactive-input-part": {
       "border-radius": "var(--islands-widget-radius) !important",
-      "overflow": "hidden !important"
+      "overflow": "visible !important",
+      "display": "flex !important",
+      "flex-direction": "column !important"
+   },
+   ".interactive-input-part .monaco-editor": {
+      "overflow": "visible !important"
    },
 
    ".monaco-button-dropdown-separator": {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -12,14 +12,21 @@ Write-Host ""
 Write-Host "Step 1: Restoring VS Code settings..."
 $settingsDir = "$env:APPDATA\Code\User"
 $settingsFile = Join-Path $settingsDir "settings.json"
-$backupFile = "$settingsFile.pre-islands-dark"
 
-if (Test-Path $backupFile) {
-    Copy-Item $backupFile $settingsFile -Force
+# Look for timestamped backups first, then the legacy backup name
+$backupDir = Split-Path $settingsFile
+$backups = @()
+if (Test-Path $backupDir) {
+    $backups = Get-ChildItem "$backupDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+}
+
+if ($backups.Count -gt 0) {
+    $latestBackup = $backups[0].FullName
+    Copy-Item $latestBackup $settingsFile -Force
     Write-Host "Settings restored from backup" -ForegroundColor Green
-    Write-Host "   Backup file: $backupFile"
+    Write-Host "   Backup file: $latestBackup"
 } else {
-    Write-Host "No backup found at $backupFile" -ForegroundColor Yellow
+    Write-Host "No backup found" -ForegroundColor Yellow
     Write-Host "   You may need to manually update your VS Code settings."
 }
 
@@ -42,27 +49,35 @@ if (Test-Path $extDir) {
     Write-Host "Extension directory not found (may already be removed)" -ForegroundColor Yellow
 }
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 Write-Host ""
-Write-Host "Step 4: Unregistering extension..."
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
-try {
-    if (Test-Path $extJsonPath) {
-        $extensions = Get-Content $extJsonPath -Raw | ConvertFrom-Json
-        $before = $extensions.Count
-        $extensions = @($extensions | Where-Object {
-            $_.identifier.id -ne 'bwya77.islands-dark' -and
-            $_.identifier.id -ne 'your-publisher-name.islands-dark'
-        })
-        if ($extensions.Count -lt $before) {
-            $extensions | ConvertTo-Json -Depth 10 -Compress | Set-Content $extJsonPath
-            Write-Host "Extension unregistered" -ForegroundColor Green
-        } else {
-            Write-Host "Extension was not registered" -ForegroundColor Yellow
+Write-Host "Step 4: Uninstalling extension from VS Code..."
+
+# Check if VS Code CLI is available
+$codePath = Get-Command "code" -ErrorAction SilentlyContinue
+if (-not $codePath) {
+    $possiblePaths = @(
+        "$env:LOCALAPPDATA\Programs\Microsoft VS Code\bin\code.cmd",
+        "$env:ProgramFiles\Microsoft VS Code\bin\code.cmd",
+        "${env:ProgramFiles(x86)}\Microsoft VS Code\bin\code.cmd"
+    )
+    foreach ($path in $possiblePaths) {
+        if (Test-Path $path) {
+            $env:Path += ";$(Split-Path $path)"
+            break
         }
     }
+}
+
+try {
+    $null = code --uninstall-extension bwya77.islands-dark --force 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Extension uninstalled via VS Code CLI" -ForegroundColor Green
+    } else {
+        Write-Host "Extension not installed via marketplace (or already removed)" -ForegroundColor Yellow
+    }
 } catch {
-    Write-Host "Could not update extensions.json" -ForegroundColor Yellow
+    Write-Host "Could not uninstall extension via VS Code CLI" -ForegroundColor Yellow
 }
 
 # Step 5: Change theme

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,14 +20,19 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
-BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
 
-if [ -f "$BACKUP_FILE" ]; then
-    cp "$BACKUP_FILE" "$SETTINGS_FILE"
+# Look for timestamped backups first, then the legacy backup name
+LATEST_BACKUP=""
+if [ -d "$SETTINGS_DIR" ]; then
+    LATEST_BACKUP=$(ls -t "$SETTINGS_DIR"/settings.json.pre-islands-dark* 2>/dev/null | head -1)
+fi
+
+if [ -n "$LATEST_BACKUP" ] && [ -f "$LATEST_BACKUP" ]; then
+    cp "$LATEST_BACKUP" "$SETTINGS_FILE"
     echo -e "${GREEN}✓ Settings restored from backup${NC}"
-    echo "   Backup file: $BACKUP_FILE"
+    echo "   Backup file: $LATEST_BACKUP"
 else
-    echo -e "${YELLOW}⚠️  No backup found at $BACKUP_FILE${NC}"
+    echo -e "${YELLOW}⚠️  No backup found${NC}"
     echo "   You may need to manually update your VS Code settings."
 fi
 
@@ -50,35 +55,17 @@ else
     echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
 fi
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 echo ""
-echo "📋 Step 4: Unregistering extension..."
-if command -v node &> /dev/null; then
-    node << 'UNREGISTER_SCRIPT'
-const fs = require('fs');
-const path = require('path');
-
-const extJsonPath = path.join(process.env.HOME, '.vscode', 'extensions', 'extensions.json');
-if (fs.existsSync(extJsonPath)) {
-    try {
-        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
-        const before = extensions.length;
-        extensions = extensions.filter(e =>
-            e.identifier?.id !== 'bwya77.islands-dark' &&
-            e.identifier?.id !== 'your-publisher-name.islands-dark'
-        );
-        if (extensions.length < before) {
-            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
-            console.log('Extension unregistered');
-        } else {
-            console.log('Extension was not registered');
-        }
-    } catch (e) {
-        console.log('Could not update extensions.json');
-    }
-}
-UNREGISTER_SCRIPT
-    echo -e "${GREEN}✓ Extension unregistered${NC}"
+echo "📋 Step 4: Uninstalling extension from VS Code..."
+if command -v code &> /dev/null; then
+    if code --uninstall-extension bwya77.islands-dark --force 2>/dev/null; then
+        echo -e "${GREEN}✓ Extension uninstalled via VS Code CLI${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Extension not installed (or already removed)${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠️  VS Code CLI not found - extension directory was already removed in Step 3${NC}"
 fi
 
 # Step 5: Change theme


### PR DESCRIPTION
## Summary

This PR addresses multiple open issues and incorporates fixes from several open PRs into a single cohesive change.

## Issues Fixed

### CSS / Theme Fixes (`settings.json`)

- **#142, #109 — Multi-select not visible in Explorer**: The `.selected` style was set to `background: transparent`, making multi-selected items invisible. Now gives selected items a subtle visible background gradient.
- **#124 — Explorer items hidden**: The `.explorer-viewlet .split-view-container` had `margin-top: -22px` which shifted content up and clipped top items. Removed the negative margin.
- **Copilot sidebar chat input overlap** (from PRs #133, #117): Added proper flex layout for the auxiliary bar's interactive session, sticky chat input positioning, and overflow fixes so the Copilot chat input isn't clipped.
- **Bottom panel chat input clipping**: Changed `overflow: hidden` to `overflow: visible` with flex layout for `.chat-input-container` and `.interactive-input-part`.
- Added `.part.editor > .modal-editor-header` height fix (from PR #133).
- Bumped settings version to v0.0.3.

### Install Script Fixes (`install.ps1`, `install.sh`)

- **#113, #135, #111 — Destructive `extensions.json` deletion removed**: Both install scripts no longer delete `~/.vscode/extensions/extensions.json`. This was the root cause of users losing all their installed extensions.
- **#135, #111 — Settings merge instead of overwrite**: Instead of replacing `settings.json`, the installer now merges Islands Dark theme settings into existing user settings. Theme keys win (so fixes are applied), but user's non-theme settings are preserved.
  - `install.ps1`: Uses PowerShell's `ConvertFrom-Json` with JSONC stripping.
  - `install.sh`: Uses `jq` for merge. If `jq` is unavailable or parsing fails, settings are left untouched with instructions for manual merge (never overwrites).
- **Timestamped backups**: Backups are now timestamped (e.g., `settings.json.pre-islands-dark.20240101-120000`) instead of overwriting a single backup file.

### Uninstall Script Fixes (`uninstall.ps1`, `uninstall.sh`)

- **#113 — No more `extensions.json` manipulation**: Replaced manual `extensions.json` parsing/filtering (which could corrupt the file) with `code --uninstall-extension bwya77.islands-dark --force`. The manual directory removal is kept as an additional cleanup step.
- Uninstall scripts now find and restore the latest timestamped backup.
- Added VS Code CLI detection to `uninstall.ps1`.

## Relationship to Open PRs

This PR incorporates the spirit of several open PRs:
- **PR #134** (preserve settings.json) — Implemented with adjusted merge direction (theme keys win for correctness)
- **PR #119** (don't remove extensions) — Implemented
- **PR #133** (Copilot sidebar fixes) — CSS changes applied
- **PR #117** (chat input overlap) — CSS changes applied
- **PR #67** (remove scaleY transforms) — The `scaleY` transforms were already removed from main; this PR addresses the remaining `margin-top: -22px` issue

## Testing

- Verified `settings.json` is valid JSON
- Confirmed no remaining references to `extensions.json` in any install/uninstall script