### PR TITLE
feat: full state tracking in install and complete revert in uninstall

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -82,6 +82,17 @@ if (-not (Test-Path $fontDir)) {
     New-Item -ItemType Directory -Path $fontDir -Force | Out-Null
 }
 
+# Track which fonts already existed (for clean uninstall)
+$fontPreExistence = @{}
+$fontFiles = Get-ChildItem "$scriptDir\fonts\*.otf" -ErrorAction SilentlyContinue
+foreach ($f in $fontFiles) {
+    $destPath = Join-Path $fontDir $f.Name
+    $fontPreExistence[$f.Name] = @{
+        wasPresentBeforeInstall = (Test-Path $destPath)
+        installedPath = $destPath
+    }
+}
+
 try {
     $fonts = Get-ChildItem "$scriptDir\fonts\*.otf"
     foreach ($font in $fonts) {
@@ -229,6 +240,55 @@ if (Test-Path $settingsFile) {
 } else {
     Copy-Item "$scriptDir\settings.json" $settingsFile -Force
     Write-Host "Islands Dark settings applied" -ForegroundColor Green
+}
+
+# Save pre-install state for clean uninstall (only on first install)
+$stateFile = Join-Path $settingsDir ".islands-dark-state.json"
+if (-not (Test-Path $stateFile)) {
+    $state = [ordered]@{
+        previousColorTheme = "Default Dark+"
+        previousIconTheme  = ""
+        customUiStyleWasInstalled = $false
+        settingsBackupPath = ""
+        fonts = @{}
+        installedAt = (Get-Date -Format "o")
+    }
+
+    # Read previous theme from the backup (pre-merge settings)
+    if ($backupFile -and (Test-Path $backupFile)) {
+        try {
+            $backupRaw = Get-Content $backupFile -Raw
+            try { $backupSettings = $backupRaw | ConvertFrom-Json }
+            catch { $backupSettings = (Strip-Jsonc $backupRaw) | ConvertFrom-Json }
+
+            if ($backupSettings.'workbench.colorTheme') {
+                $state.previousColorTheme = $backupSettings.'workbench.colorTheme'
+            }
+            if ($backupSettings.'workbench.iconTheme') {
+                $state.previousIconTheme = $backupSettings.'workbench.iconTheme'
+            }
+        } catch {}
+        $state.settingsBackupPath = $backupFile
+    }
+
+    # Check if Custom UI Style was already installed
+    $cuiExtDirs = Get-ChildItem "$env:USERPROFILE\.vscode\extensions\subframe7536.custom-ui-style-*" -Directory -ErrorAction SilentlyContinue
+    if ($cuiExtDirs) {
+        $state.customUiStyleWasInstalled = $true
+    }
+
+    # Track which fonts were installed (use pre-install check from Step 3)
+    $fontState = [ordered]@{}
+    foreach ($key in $fontPreExistence.Keys) {
+        $fontState[$key] = [ordered]@{
+            wasPresentBeforeInstall = $fontPreExistence[$key].wasPresentBeforeInstall
+            installedPath = $fontPreExistence[$key].installedPath
+        }
+    }
+    $state.fonts = [PSCustomObject]$fontState
+
+    [PSCustomObject]$state | ConvertTo-Json -Depth 10 | Set-Content $stateFile
+    Write-Host "Pre-install state saved for clean uninstall" -ForegroundColor DarkGray
 }
 
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -62,13 +62,6 @@ if (Test-Path "$extDir\themes") {
     exit 1
 }
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
-if (Test-Path $extJsonPath) {
-    Remove-Item $extJsonPath -Force
-    Write-Host "Cleared extensions.json (VS Code will rebuild it)" -ForegroundColor Green
-}
 
 Write-Host ""
 Write-Host "Step 2: Installing Custom UI Style extension..."
@@ -116,18 +109,78 @@ if (-not (Test-Path $settingsDir)) {
 
 $settingsFile = Join-Path $settingsDir "settings.json"
 
-# Backup existing settings if they exist
+# Strip JSONC features (comments, trailing commas) so ConvertFrom-Json can parse
+function Strip-Jsonc {
+    param([string]$Text)
+    # Remove single-line comments
+    $Text = $Text -replace '(?m)//.*$', ''
+    # Remove multi-line comments
+    $Text = $Text -replace '/\*[\s\S]*?\*/', ''
+    # Remove trailing commas before } or ]
+    $Text = $Text -replace ',\s*([}\]])', '$1'
+    return $Text
+}
+
+$newSettingsRaw = Get-Content "$scriptDir\settings.json" -Raw
+$newSettings = (Strip-Jsonc $newSettingsRaw) | ConvertFrom-Json
+
+# If the user has existing settings, merge instead of overwrite.
+# Islands Dark theme keys win so updated fixes are applied correctly.
+# Non-theme user settings are preserved.
 if (Test-Path $settingsFile) {
-    $backupFile = "$settingsFile.pre-islands-dark"
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $backupFile = "$settingsFile.pre-islands-dark.$timestamp"
     Copy-Item $settingsFile $backupFile -Force
     Write-Host "Existing settings.json backed up to:" -ForegroundColor Yellow
     Write-Host "   $backupFile"
     Write-Host "   You can restore your old settings from this file if needed."
-}
 
-# Copy Islands Dark settings
-Copy-Item "$scriptDir\settings.json" $settingsFile -Force
-Write-Host "Islands Dark settings applied" -ForegroundColor Green
+    try {
+        $existingRaw = Get-Content $settingsFile -Raw
+        $existingSettings = (Strip-Jsonc $existingRaw) | ConvertFrom-Json
+
+        # Start with user's existing settings, then overlay Islands Dark theme settings.
+        # Theme keys win so fixes/updates are applied correctly.
+        $mergedSettings = [ordered]@{}
+
+        # First, copy all existing user settings
+        $existingSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+
+        # Then overlay Islands Dark settings (theme keys win)
+        $newSettings.PSObject.Properties | ForEach-Object {
+            $mergedSettings[$_.Name] = $_.Value
+        }
+
+        # Deep merge custom-ui-style.stylesheet so user's extra CSS rules survive
+        # but Islands Dark's selectors always get the latest fixes
+        $stylesheetKey = 'custom-ui-style.stylesheet'
+        if ($existingSettings.$stylesheetKey -and $newSettings.$stylesheetKey) {
+            $mergedStylesheet = [ordered]@{}
+            # Start with user's custom CSS selectors
+            $existingSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            # Overlay Islands Dark selectors (theme wins for its own selectors)
+            $newSettings.$stylesheetKey.PSObject.Properties | ForEach-Object {
+                $mergedStylesheet[$_.Name] = $_.Value
+            }
+            $mergedSettings[$stylesheetKey] = [PSCustomObject]$mergedStylesheet
+        }
+
+        [PSCustomObject]$mergedSettings | ConvertTo-Json -Depth 100 | Set-Content $settingsFile
+        Write-Host "Settings merged (your non-theme settings preserved, theme settings updated)" -ForegroundColor Green
+    } catch {
+        Write-Host "Could not parse existing settings.json - leaving it untouched" -ForegroundColor Yellow
+        Write-Host "   Your backup is at: $backupFile" -ForegroundColor DarkGray
+        Write-Host "   To apply Islands Dark settings, manually merge from: $scriptDir\settings.json" -ForegroundColor DarkGray
+        Write-Host "   Error: $($_.Exception.Message)" -ForegroundColor DarkGray
+    }
+} else {
+    Copy-Item "$scriptDir\settings.json" $settingsFile -Force
+    Write-Host "Islands Dark settings applied" -ForegroundColor Green
+}
 
 Write-Host ""
 Write-Host "Step 5: Enabling Custom UI Style..."

--- a/install.ps1
+++ b/install.ps1
@@ -109,20 +109,64 @@ if (-not (Test-Path $settingsDir)) {
 
 $settingsFile = Join-Path $settingsDir "settings.json"
 
-# Strip JSONC features (comments, trailing commas) so ConvertFrom-Json can parse
+# Strip JSONC features (comments, trailing commas) so ConvertFrom-Json can parse.
+# Uses a character-by-character approach to avoid stripping // inside quoted strings.
 function Strip-Jsonc {
     param([string]$Text)
-    # Remove single-line comments
-    $Text = $Text -replace '(?m)//.*$', ''
-    # Remove multi-line comments
-    $Text = $Text -replace '/\*[\s\S]*?\*/', ''
+    $result = [System.Text.StringBuilder]::new($Text.Length)
+    $inString = $false
+    $escaped = $false
+    $i = 0
+    while ($i -lt $Text.Length) {
+        $c = $Text[$i]
+        if ($escaped) {
+            [void]$result.Append($c)
+            $escaped = $false
+            $i++
+            continue
+        }
+        if ($c -eq '\' -and $inString) {
+            [void]$result.Append($c)
+            $escaped = $true
+            $i++
+            continue
+        }
+        if ($c -eq '"') {
+            $inString = -not $inString
+            [void]$result.Append($c)
+            $i++
+            continue
+        }
+        if (-not $inString) {
+            # Single-line comment: skip to end of line
+            if ($c -eq '/' -and ($i + 1) -lt $Text.Length -and $Text[$i + 1] -eq '/') {
+                while ($i -lt $Text.Length -and $Text[$i] -ne "`n") { $i++ }
+                continue
+            }
+            # Multi-line comment: skip to closing */
+            if ($c -eq '/' -and ($i + 1) -lt $Text.Length -and $Text[$i + 1] -eq '*') {
+                $i += 2
+                while ($i -lt $Text.Length) {
+                    if ($Text[$i] -eq '*' -and ($i + 1) -lt $Text.Length -and $Text[$i + 1] -eq '/') {
+                        $i += 2
+                        break
+                    }
+                    $i++
+                }
+                continue
+            }
+        }
+        [void]$result.Append($c)
+        $i++
+    }
+    $resultStr = $result.ToString()
     # Remove trailing commas before } or ]
-    $Text = $Text -replace ',\s*([}\]])', '$1'
-    return $Text
+    $resultStr = $resultStr -replace ',\s*([}\]])', '$1'
+    return $resultStr
 }
 
-$newSettingsRaw = Get-Content "$scriptDir\settings.json" -Raw
-$newSettings = (Strip-Jsonc $newSettingsRaw) | ConvertFrom-Json
+# Our own settings.json is valid JSON - parse directly
+$newSettings = Get-Content "$scriptDir\settings.json" -Raw | ConvertFrom-Json
 
 # If the user has existing settings, merge instead of overwrite.
 # Islands Dark theme keys win so updated fixes are applied correctly.
@@ -137,7 +181,12 @@ if (Test-Path $settingsFile) {
 
     try {
         $existingRaw = Get-Content $settingsFile -Raw
-        $existingSettings = (Strip-Jsonc $existingRaw) | ConvertFrom-Json
+        # Try direct parse first; fall back to JSONC stripping for user files with comments
+        try {
+            $existingSettings = $existingRaw | ConvertFrom-Json
+        } catch {
+            $existingSettings = (Strip-Jsonc $existingRaw) | ConvertFrom-Json
+        }
 
         # Start with user's existing settings, then overlay Islands Dark theme settings.
         # Theme keys win so fixes/updates are applied correctly.

--- a/install.sh
+++ b/install.sh
@@ -57,10 +57,22 @@ fi
 
 echo ""
 echo "🔤 Step 3: Installing Bear Sans UI fonts..."
+
+# Track font pre-existence before installing
+FONT_PRE_STATE=""
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS
     FONT_DIR="$HOME/Library/Fonts"
     echo "   Installing fonts to: $FONT_DIR"
+    for f in "$SCRIPT_DIR/fonts/"*.otf; do
+        [ -f "$f" ] || continue
+        fname=$(basename "$f")
+        if [ -f "$FONT_DIR/$fname" ]; then
+            FONT_PRE_STATE="${FONT_PRE_STATE}\"${fname}\": {\"wasPresentBeforeInstall\": true, \"installedPath\": \"${FONT_DIR}/${fname}\"},"
+        else
+            FONT_PRE_STATE="${FONT_PRE_STATE}\"${fname}\": {\"wasPresentBeforeInstall\": false, \"installedPath\": \"${FONT_DIR}/${fname}\"},"
+        fi
+    done
     cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
     echo -e "${GREEN}✓ Fonts installed to Font Book${NC}"
     echo "   Note: You may need to restart applications to use the new fonts"
@@ -69,6 +81,15 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     FONT_DIR="$HOME/.local/share/fonts"
     mkdir -p "$FONT_DIR"
     echo "   Installing fonts to: $FONT_DIR"
+    for f in "$SCRIPT_DIR/fonts/"*.otf; do
+        [ -f "$f" ] || continue
+        fname=$(basename "$f")
+        if [ -f "$FONT_DIR/$fname" ]; then
+            FONT_PRE_STATE="${FONT_PRE_STATE}\"${fname}\": {\"wasPresentBeforeInstall\": true, \"installedPath\": \"${FONT_DIR}/${fname}\"},"
+        else
+            FONT_PRE_STATE="${FONT_PRE_STATE}\"${fname}\": {\"wasPresentBeforeInstall\": false, \"installedPath\": \"${FONT_DIR}/${fname}\"},"
+        fi
+    done
     cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
     fc-cache -f 2>/dev/null || true
     echo -e "${GREEN}✓ Fonts installed${NC}"
@@ -76,6 +97,8 @@ else
     echo -e "${YELLOW}⚠️  Could not detect OS type for automatic font installation${NC}"
     echo "   Please manually install the fonts from the 'fonts/' folder"
 fi
+# Remove trailing comma from font state
+FONT_PRE_STATE="${FONT_PRE_STATE%,}"
 
 echo ""
 echo "⚙️  Step 4: Applying VS Code settings..."
@@ -117,6 +140,40 @@ else
     # No existing settings - just copy
     cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
     echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+fi
+
+# Save pre-install state for clean uninstall (only on first install)
+STATE_FILE="$SETTINGS_DIR/.islands-dark-state.json"
+if [ ! -f "$STATE_FILE" ]; then
+    PREV_THEME="Default Dark+"
+    PREV_ICON_THEME=""
+    CUI_WAS_INSTALLED="false"
+    BACKUP_PATH="${BACKUP_FILE:-}"
+
+    # Read previous theme from backup
+    if [ -n "$BACKUP_PATH" ] && [ -f "$BACKUP_PATH" ]; then
+        if command -v jq &> /dev/null; then
+            PREV_THEME=$(jq -r '."workbench.colorTheme" // "Default Dark+"' "$BACKUP_PATH" 2>/dev/null || echo "Default Dark+")
+            PREV_ICON_THEME=$(jq -r '."workbench.iconTheme" // ""' "$BACKUP_PATH" 2>/dev/null || echo "")
+        fi
+    fi
+
+    # Check if Custom UI Style was already installed
+    if ls "$HOME/.vscode/extensions/subframe7536.custom-ui-style-"* 1>/dev/null 2>&1; then
+        CUI_WAS_INSTALLED="true"
+    fi
+
+    cat > "$STATE_FILE" << STATEEOF
+{
+  "previousColorTheme": "$PREV_THEME",
+  "previousIconTheme": "$PREV_ICON_THEME",
+  "customUiStyleWasInstalled": $CUI_WAS_INSTALLED,
+  "settingsBackupPath": "$BACKUP_PATH",
+  "fonts": {${FONT_PRE_STATE}},
+  "installedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+STATEEOF
+    echo -e "${GREEN}✓ Pre-install state saved for clean uninstall${NC}"
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -46,14 +46,6 @@ else
     exit 1
 fi
 
-# Remove extensions.json so VS Code rebuilds it cleanly on next launch
-# (previous versions of this script wrote invalid content to this file)
-EXT_JSON="$HOME/.vscode/extensions/extensions.json"
-if [ -f "$EXT_JSON" ]; then
-    rm -f "$EXT_JSON"
-    echo -e "${GREEN}✓ Cleared extensions.json (VS Code will rebuild it)${NC}"
-fi
-
 echo ""
 echo "🔧 Step 2: Installing Custom UI Style extension..."
 if code --install-extension subframe7536.custom-ui-style --force; then
@@ -95,18 +87,37 @@ fi
 mkdir -p "$SETTINGS_DIR"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
-# Backup existing settings if they exist
+# Backup existing settings if they exist, then merge
 if [ -f "$SETTINGS_FILE" ]; then
-    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+    TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark.$TIMESTAMP"
     cp "$SETTINGS_FILE" "$BACKUP_FILE"
     echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
     echo "   $BACKUP_FILE"
     echo "   You can restore your old settings from this file if needed."
-fi
 
-# Copy Islands Dark settings
-cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
-echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+    if command -v jq &> /dev/null; then
+        # Merge: user's non-theme settings are preserved, Islands Dark theme keys win
+        # This ensures updated fixes are applied while keeping user customizations
+        if MERGED=$(jq -s '.[0] * .[1]' "$SETTINGS_FILE" "$SCRIPT_DIR/settings.json" 2>/dev/null); then
+            echo "$MERGED" > "$SETTINGS_FILE"
+            echo -e "${GREEN}✓ Settings merged (your non-theme settings preserved, theme settings updated)${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Could not parse existing settings.json - leaving it untouched${NC}"
+            echo "   Your backup is at: $BACKUP_FILE"
+            echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        fi
+    else
+        echo -e "${YELLOW}⚠️  jq not found - cannot merge settings safely${NC}"
+        echo "   Your backup is at: $BACKUP_FILE"
+        echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        echo "   Or install jq (https://jqlang.github.io/jq/) and re-run this script"
+    fi
+else
+    # No existing settings - just copy
+    cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+fi
 
 echo ""
 echo "🚀 Step 5: Enabling Custom UI Style..."

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-  "// Islands Dark Settings v0.0.2": "",
+  "// Islands Dark Settings v0.0.3": "",
   "workbench.colorTheme": "Islands Dark",
   "editor.fontFamily": "IBM Plex Mono",
   "terminal.integrated.fontFamily": "FiraCode Nerd Font Mono",
@@ -55,7 +55,7 @@
       "outline-offset": "-1px !important"
    },
    ".explorer-viewlet .split-view-container": {
-      "margin-top": "-22px !important"
+      "margin-top": "0 !important"
    },
    ".part.sidebar .header": {
       "padding-right": "20px !important"
@@ -78,8 +78,8 @@
       "transition": "background 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important"
    },
    ".part.sidebar .monaco-list-row.selected": {
-      "background": "transparent !important",
-      "box-shadow": "none !important",
+      "background": "linear-gradient(135deg, rgba(49,50,56,0.35), rgba(37,38,44,0.25)) !important",
+      "box-shadow": "inset 0 0 0 1px rgba(255,255,255,0.04) !important",
       "outline": "none !important"
    },
    ".part.sidebar .monaco-list-row.focused": {
@@ -115,6 +115,9 @@
       "border-bottom": "1px solid rgba(255,255,255,0.03) !important",
       "border-right": "1px solid rgba(255,255,255,0.03) !important",
       "box-shadow": "0 2px 8px 0 rgba(0,0,0,0.3) !important"
+   },
+   ".part.editor > .modal-editor-header": {
+      "height": "60px !important"
    },
    ".editor-actions": {
       "padding-right": "20px !important",
@@ -247,10 +250,13 @@
       "z-index": "1 !important"
    },
    ".part.panel.bottom > .content": {
-      "margin-top": "-6px !important",
+      "margin-top": "0 !important",
       "position": "relative !important",
       "border-radius": "0 0 calc(var(--islands-panel-radius) - var(--islands-panel-gap)) calc(var(--islands-panel-radius) - var(--islands-panel-gap)) !important",
       "overflow": "hidden !important"
+   },
+   ".part.panel.bottom:has(.terminal-outer-container) > .content": {
+      "margin-top": "-7px !important"
    },
    ".part.panel.bottom .pane": {
       "border-bottom": "none !important"
@@ -467,10 +473,42 @@
       "width": "100% !important"
    },
    ".part.auxiliarybar .split-view-view": {
-      "max-height": "calc(100% - 24px) !important"
+      "max-height": "100% !important",
+      "overflow": "hidden !important",
+      "display": "flex !important",
+      "flex-direction": "column !important"
    },
    ".part.auxiliarybar .header": {
       "padding-left": "8px !important"
+   },
+   ".part.auxiliarybar .chat-input-part": {
+      "position": "sticky !important",
+      "bottom": "0 !important",
+      "z-index": "10 !important"
+   },
+   ".part.auxiliarybar .interactive-input-part": {
+      "border-radius": "var(--islands-widget-radius) !important",
+      "overflow": "visible !important",
+      "flex-shrink": "0 !important"
+   },
+   ".part.auxiliarybar .interactive-session": {
+      "display": "flex !important",
+      "flex-direction": "column !important",
+      "height": "100% !important",
+      "overflow": "hidden !important"
+   },
+   ".part.auxiliarybar .interactive-list": {
+      "flex": "1 1 auto !important",
+      "overflow-y": "auto !important",
+      "min-height": "0 !important"
+   },
+   ".part.auxiliarybar .chat-input-container": {
+      "flex-shrink": "0 !important",
+      "overflow": "visible !important",
+      "min-height": "fit-content !important"
+   },
+   ".part.auxiliarybar .monaco-inputbox": {
+      "overflow": "visible !important"
    },
    ".quick-input-widget": {
       "border-radius": "var(--islands-widget-radius) !important",
@@ -551,14 +589,22 @@
       "border-left": "1px solid rgba(255,255,255,0.06) !important",
       "border-bottom": "1px solid rgba(255,255,255,0.02) !important",
       "border-right": "1px solid rgba(255,255,255,0.02) !important",
-      "overflow": "hidden !important"
+      "overflow": "visible !important",
+      "display": "flex !important",
+      "flex-direction": "column !important",
+      "align-items": "stretch !important"
    },
    ".chat-input-container .monaco-inputbox": {
       "background-color": "var(--islands-bg-surface) !important"
    },
    ".interactive-input-part": {
       "border-radius": "var(--islands-widget-radius) !important",
-      "overflow": "hidden !important"
+      "overflow": "visible !important",
+      "display": "flex !important",
+      "flex-direction": "column !important"
+   },
+   ".interactive-input-part .monaco-editor": {
+      "overflow": "visible !important"
    },
 
    ".monaco-button-dropdown-separator": {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -8,52 +8,7 @@ Write-Host "Islands Dark Theme Uninstaller for Windows" -ForegroundColor Cyan
 Write-Host "===========================================" -ForegroundColor Cyan
 Write-Host ""
 
-# Step 1: Restore old settings
-Write-Host "Step 1: Restoring VS Code settings..."
-$settingsDir = "$env:APPDATA\Code\User"
-$settingsFile = Join-Path $settingsDir "settings.json"
-
-# Look for timestamped backups first, then the legacy backup name
-$backupDir = Split-Path $settingsFile
-$backups = @()
-if (Test-Path $backupDir) {
-    $backups = Get-ChildItem "$backupDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
-}
-
-if ($backups.Count -gt 0) {
-    $latestBackup = $backups[0].FullName
-    Copy-Item $latestBackup $settingsFile -Force
-    Write-Host "Settings restored from backup" -ForegroundColor Green
-    Write-Host "   Backup file: $latestBackup"
-} else {
-    Write-Host "No backup found" -ForegroundColor Yellow
-    Write-Host "   You may need to manually update your VS Code settings."
-}
-
-# Step 2: Disable Custom UI Style
-Write-Host ""
-Write-Host "Step 2: Disabling Custom UI Style..."
-Write-Host "   Please disable Custom UI Style manually:" -ForegroundColor Yellow
-Write-Host "   1. Open Command Palette (Ctrl+Shift+P)"
-Write-Host "   2. Run 'Custom UI Style: Disable'"
-Write-Host "   3. VS Code will reload"
-
-# Step 3: Remove theme extension
-Write-Host ""
-Write-Host "Step 3: Removing Islands Dark theme extension..."
-$extDir = "$env:USERPROFILE\.vscode\extensions\bwya77.islands-dark-1.0.0"
-if (Test-Path $extDir) {
-    Remove-Item -Recurse -Force $extDir
-    Write-Host "Theme extension removed" -ForegroundColor Green
-} else {
-    Write-Host "Extension directory not found (may already be removed)" -ForegroundColor Yellow
-}
-
-# Step 4: Uninstall extension via VS Code CLI
-Write-Host ""
-Write-Host "Step 4: Uninstalling extension from VS Code..."
-
-# Check if VS Code CLI is available
+# Locate VS Code CLI
 $codePath = Get-Command "code" -ErrorAction SilentlyContinue
 if (-not $codePath) {
     $possiblePaths = @(
@@ -64,33 +19,213 @@ if (-not $codePath) {
     foreach ($path in $possiblePaths) {
         if (Test-Path $path) {
             $env:Path += ";$(Split-Path $path)"
+            $codePath = $true
             break
         }
     }
 }
 
-try {
-    $null = code --uninstall-extension bwya77.islands-dark --force 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "Extension uninstalled via VS Code CLI" -ForegroundColor Green
-    } else {
-        Write-Host "Extension not installed via marketplace (or already removed)" -ForegroundColor Yellow
+if ($codePath) {
+    Write-Host "VS Code CLI found" -ForegroundColor Green
+} else {
+    Write-Host "VS Code CLI not found - will skip CLI operations" -ForegroundColor Yellow
+}
+Write-Host ""
+
+# Load pre-install state if available
+$settingsDir = "$env:APPDATA\Code\User"
+$settingsFile = Join-Path $settingsDir "settings.json"
+$stateFile = Join-Path $settingsDir ".islands-dark-state.json"
+$state = $null
+
+if (Test-Path $stateFile) {
+    try {
+        $state = Get-Content $stateFile -Raw | ConvertFrom-Json
+        Write-Host "Found pre-install state file" -ForegroundColor Green
+    } catch {
+        Write-Host "Could not read state file" -ForegroundColor Yellow
     }
-} catch {
-    Write-Host "Could not uninstall extension via VS Code CLI" -ForegroundColor Yellow
 }
 
-# Step 5: Change theme
+# Step 1: Restore VS Code settings
+Write-Host "Step 1: Restoring VS Code settings..."
+
+$restored = $false
+
+# Try to restore from the exact backup recorded in state file
+if ($state -and $state.settingsBackupPath -and (Test-Path $state.settingsBackupPath)) {
+    Copy-Item $state.settingsBackupPath $settingsFile -Force
+    Write-Host "Settings restored from original backup" -ForegroundColor Green
+    Write-Host "   Source: $($state.settingsBackupPath)" -ForegroundColor DarkGray
+    $restored = $true
+}
+
+# Fall back to latest timestamped backup
+if (-not $restored -and (Test-Path $settingsDir)) {
+    $backups = Get-ChildItem "$settingsDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+    if ($backups.Count -gt 0) {
+        Copy-Item $backups[0].FullName $settingsFile -Force
+        Write-Host "Settings restored from backup" -ForegroundColor Green
+        Write-Host "   Source: $($backups[0].FullName)" -ForegroundColor DarkGray
+        $restored = $true
+    }
+}
+
+# If no backup exists, surgically remove Islands Dark keys from settings
+if (-not $restored -and (Test-Path $settingsFile)) {
+    Write-Host "No backup found - surgically removing Islands Dark settings..." -ForegroundColor Yellow
+    try {
+        $raw = Get-Content $settingsFile -Raw
+        try { $settings = $raw | ConvertFrom-Json }
+        catch { $settings = $null }
+
+        if ($settings) {
+            # Keys that Islands Dark adds
+            $islandsKeys = @(
+                '// Islands Dark Settings v0.0.3',
+                '// Islands Dark Settings v0.0.2',
+                'custom-ui-style.stylesheet',
+                'custom-ui-style.font',
+                'chat.viewSessions.orientation'
+            )
+
+            $cleaned = [ordered]@{}
+            $settings.PSObject.Properties | ForEach-Object {
+                if ($_.Name -notin $islandsKeys) {
+                    $cleaned[$_.Name] = $_.Value
+                }
+            }
+
+            # Restore previous theme if we have state
+            if ($state) {
+                if ($state.previousColorTheme) {
+                    $cleaned['workbench.colorTheme'] = $state.previousColorTheme
+                }
+                if ($state.previousIconTheme) {
+                    $cleaned['workbench.iconTheme'] = $state.previousIconTheme
+                }
+            } else {
+                # Reset to VS Code defaults
+                $cleaned['workbench.colorTheme'] = 'Default Dark+'
+                $cleaned.Remove('workbench.iconTheme')
+            }
+
+            [PSCustomObject]$cleaned | ConvertTo-Json -Depth 100 | Set-Content $settingsFile
+            Write-Host "Islands Dark settings removed, previous theme restored" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "Could not modify settings.json - please update manually" -ForegroundColor Yellow
+    }
+} elseif (-not $restored) {
+    Write-Host "No settings.json found" -ForegroundColor Yellow
+}
+
+# Step 2: Remove Islands Dark theme extension
 Write-Host ""
-Write-Host "Step 5: Change your color theme..."
-Write-Host "   1. Open Command Palette (Ctrl+Shift+P)"
-Write-Host "   2. Search for 'Preferences: Color Theme'"
-Write-Host "   3. Select your preferred theme"
+Write-Host "Step 2: Removing Islands Dark theme extension..."
+$extDir = "$env:USERPROFILE\.vscode\extensions\bwya77.islands-dark-1.0.0"
+if (Test-Path $extDir) {
+    Remove-Item -Recurse -Force $extDir
+    Write-Host "Theme extension directory removed" -ForegroundColor Green
+} else {
+    Write-Host "Extension directory not found (may already be removed)" -ForegroundColor Yellow
+}
+
+if ($codePath) {
+    try {
+        $null = code --uninstall-extension bwya77.islands-dark --force 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Extension uninstalled via VS Code CLI" -ForegroundColor Green
+        }
+    } catch {}
+}
+
+# Step 3: Handle Custom UI Style extension
+Write-Host ""
+Write-Host "Step 3: Handling Custom UI Style extension..."
+
+if ($state -and $state.customUiStyleWasInstalled -eq $true) {
+    # Custom UI Style was already installed before Islands Dark - leave it but disable CSS
+    Write-Host "Custom UI Style was installed before Islands Dark - leaving it installed" -ForegroundColor Green
+    Write-Host "   The Islands Dark CSS rules have been removed from your settings." -ForegroundColor DarkGray
+} else {
+    # We installed it, so uninstall it
+    if ($codePath) {
+        try {
+            $null = code --uninstall-extension subframe7536.custom-ui-style --force 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "Custom UI Style extension uninstalled" -ForegroundColor Green
+            } else {
+                Write-Host "Custom UI Style may already be removed" -ForegroundColor Yellow
+            }
+        } catch {
+            Write-Host "Could not uninstall Custom UI Style automatically" -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "Please uninstall Custom UI Style manually from VS Code Extensions" -ForegroundColor Yellow
+    }
+}
+
+# Step 4: Remove fonts that we installed
+Write-Host ""
+Write-Host "Step 4: Removing installed fonts..."
+
+if ($state -and $state.fonts) {
+    $removedCount = 0
+    $state.fonts.PSObject.Properties | ForEach-Object {
+        $fontInfo = $_.Value
+        if ($fontInfo.wasPresentBeforeInstall -eq $false -and $fontInfo.installedPath -and (Test-Path $fontInfo.installedPath)) {
+            Remove-Item $fontInfo.installedPath -Force -ErrorAction SilentlyContinue
+            $removedCount++
+        }
+    }
+    if ($removedCount -gt 0) {
+        Write-Host "$removedCount font(s) removed" -ForegroundColor Green
+    } else {
+        Write-Host "No fonts to remove (all were pre-existing)" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "No font state found - skipping font removal" -ForegroundColor Yellow
+    Write-Host "   You can manually remove Bear Sans UI fonts from: $env:LOCALAPPDATA\Microsoft\Windows\Fonts" -ForegroundColor DarkGray
+}
+
+# Step 5: Clean up state and backup files
+Write-Host ""
+Write-Host "Step 5: Cleaning up..."
+
+if (Test-Path $stateFile) {
+    Remove-Item $stateFile -Force
+    Write-Host "State file removed" -ForegroundColor DarkGray
+}
+
+# Clean up backup files
+if (Test-Path $settingsDir) {
+    $backupFiles = Get-ChildItem "$settingsDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue
+    if ($backupFiles.Count -gt 0) {
+        $backupFiles | Remove-Item -Force -ErrorAction SilentlyContinue
+        Write-Host "$($backupFiles.Count) backup file(s) removed" -ForegroundColor DarkGray
+    }
+}
+
+# Step 6: Reload VS Code
+Write-Host ""
+Write-Host "Step 6: Reloading VS Code..."
+
+if ($codePath) {
+    Write-Host "   Closing VS Code..." -ForegroundColor Cyan
+    Stop-Process -Name "Code" -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
+    Write-Host "   Relaunching VS Code..." -ForegroundColor Cyan
+    Start-Process "code" -ErrorAction SilentlyContinue
+} else {
+    Write-Host "   Please restart VS Code manually to complete the uninstall." -ForegroundColor Yellow
+}
 
 Write-Host ""
 Write-Host "Islands Dark has been uninstalled!" -ForegroundColor Green
 Write-Host ""
-Write-Host "   Reload VS Code to complete the process."
+Write-Host "Note: If you see CSS artifacts, open Command Palette (Ctrl+Shift+P)" -ForegroundColor Yellow
+Write-Host "and run 'Custom UI Style: Disable' to clean up injected styles." -ForegroundColor Yellow
 Write-Host ""
 
 Start-Sleep -Seconds 3

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -12,14 +12,21 @@ Write-Host ""
 Write-Host "Step 1: Restoring VS Code settings..."
 $settingsDir = "$env:APPDATA\Code\User"
 $settingsFile = Join-Path $settingsDir "settings.json"
-$backupFile = "$settingsFile.pre-islands-dark"
 
-if (Test-Path $backupFile) {
-    Copy-Item $backupFile $settingsFile -Force
+# Look for timestamped backups first, then the legacy backup name
+$backupDir = Split-Path $settingsFile
+$backups = @()
+if (Test-Path $backupDir) {
+    $backups = Get-ChildItem "$backupDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+}
+
+if ($backups.Count -gt 0) {
+    $latestBackup = $backups[0].FullName
+    Copy-Item $latestBackup $settingsFile -Force
     Write-Host "Settings restored from backup" -ForegroundColor Green
-    Write-Host "   Backup file: $backupFile"
+    Write-Host "   Backup file: $latestBackup"
 } else {
-    Write-Host "No backup found at $backupFile" -ForegroundColor Yellow
+    Write-Host "No backup found" -ForegroundColor Yellow
     Write-Host "   You may need to manually update your VS Code settings."
 }
 
@@ -42,27 +49,35 @@ if (Test-Path $extDir) {
     Write-Host "Extension directory not found (may already be removed)" -ForegroundColor Yellow
 }
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 Write-Host ""
-Write-Host "Step 4: Unregistering extension..."
-$extJsonPath = "$env:USERPROFILE\.vscode\extensions\extensions.json"
-try {
-    if (Test-Path $extJsonPath) {
-        $extensions = Get-Content $extJsonPath -Raw | ConvertFrom-Json
-        $before = $extensions.Count
-        $extensions = @($extensions | Where-Object {
-            $_.identifier.id -ne 'bwya77.islands-dark' -and
-            $_.identifier.id -ne 'your-publisher-name.islands-dark'
-        })
-        if ($extensions.Count -lt $before) {
-            $extensions | ConvertTo-Json -Depth 10 -Compress | Set-Content $extJsonPath
-            Write-Host "Extension unregistered" -ForegroundColor Green
-        } else {
-            Write-Host "Extension was not registered" -ForegroundColor Yellow
+Write-Host "Step 4: Uninstalling extension from VS Code..."
+
+# Check if VS Code CLI is available
+$codePath = Get-Command "code" -ErrorAction SilentlyContinue
+if (-not $codePath) {
+    $possiblePaths = @(
+        "$env:LOCALAPPDATA\Programs\Microsoft VS Code\bin\code.cmd",
+        "$env:ProgramFiles\Microsoft VS Code\bin\code.cmd",
+        "${env:ProgramFiles(x86)}\Microsoft VS Code\bin\code.cmd"
+    )
+    foreach ($path in $possiblePaths) {
+        if (Test-Path $path) {
+            $env:Path += ";$(Split-Path $path)"
+            break
         }
     }
+}
+
+try {
+    $null = code --uninstall-extension bwya77.islands-dark --force 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Extension uninstalled via VS Code CLI" -ForegroundColor Green
+    } else {
+        Write-Host "Extension not installed via marketplace (or already removed)" -ForegroundColor Yellow
+    }
 } catch {
-    Write-Host "Could not update extensions.json" -ForegroundColor Yellow
+    Write-Host "Could not uninstall extension via VS Code CLI" -ForegroundColor Yellow
 }
 
 # Step 5: Change theme

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,71 +12,181 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Step 1: Restore old settings
-echo "⚙️  Step 1: Restoring VS Code settings..."
+# Check if code command is available
+HAS_CLI=false
+if command -v code &> /dev/null; then
+    HAS_CLI=true
+    echo -e "${GREEN}✓ VS Code CLI found${NC}"
+else
+    echo -e "${YELLOW}⚠️  VS Code CLI not found - will skip CLI operations${NC}"
+fi
+echo ""
+
+# Determine settings directory
 SETTINGS_DIR="$HOME/.config/Code/User"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     SETTINGS_DIR="$HOME/Library/Application Support/Code/User"
 fi
 
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+STATE_FILE="$SETTINGS_DIR/.islands-dark-state.json"
 
-# Look for timestamped backups first, then the legacy backup name
-LATEST_BACKUP=""
-if [ -d "$SETTINGS_DIR" ]; then
+# Load pre-install state if available
+PREV_THEME="Default Dark+"
+PREV_ICON_THEME=""
+CUI_WAS_INSTALLED="false"
+BACKUP_PATH=""
+HAS_STATE=false
+
+if [ -f "$STATE_FILE" ]; then
+    HAS_STATE=true
+    echo -e "${GREEN}✓ Found pre-install state file${NC}"
+    if command -v jq &> /dev/null; then
+        PREV_THEME=$(jq -r '.previousColorTheme // "Default Dark+"' "$STATE_FILE" 2>/dev/null || echo "Default Dark+")
+        PREV_ICON_THEME=$(jq -r '.previousIconTheme // ""' "$STATE_FILE" 2>/dev/null || echo "")
+        CUI_WAS_INSTALLED=$(jq -r '.customUiStyleWasInstalled // false' "$STATE_FILE" 2>/dev/null || echo "false")
+        BACKUP_PATH=$(jq -r '.settingsBackupPath // ""' "$STATE_FILE" 2>/dev/null || echo "")
+    fi
+fi
+
+# Step 1: Restore VS Code settings
+echo "⚙️  Step 1: Restoring VS Code settings..."
+
+RESTORED=false
+
+# Try to restore from the exact backup recorded in state file
+if [ -n "$BACKUP_PATH" ] && [ -f "$BACKUP_PATH" ]; then
+    cp "$BACKUP_PATH" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Settings restored from original backup${NC}"
+    echo "   Source: $BACKUP_PATH"
+    RESTORED=true
+fi
+
+# Fall back to latest timestamped backup
+if [ "$RESTORED" = false ] && [ -d "$SETTINGS_DIR" ]; then
     LATEST_BACKUP=$(ls -t "$SETTINGS_DIR"/settings.json.pre-islands-dark* 2>/dev/null | head -1)
+    if [ -n "$LATEST_BACKUP" ] && [ -f "$LATEST_BACKUP" ]; then
+        cp "$LATEST_BACKUP" "$SETTINGS_FILE"
+        echo -e "${GREEN}✓ Settings restored from backup${NC}"
+        echo "   Source: $LATEST_BACKUP"
+        RESTORED=true
+    fi
 fi
 
-if [ -n "$LATEST_BACKUP" ] && [ -f "$LATEST_BACKUP" ]; then
-    cp "$LATEST_BACKUP" "$SETTINGS_FILE"
-    echo -e "${GREEN}✓ Settings restored from backup${NC}"
-    echo "   Backup file: $LATEST_BACKUP"
-else
-    echo -e "${YELLOW}⚠️  No backup found${NC}"
-    echo "   You may need to manually update your VS Code settings."
+# If no backup exists, surgically remove Islands Dark keys
+if [ "$RESTORED" = false ] && [ -f "$SETTINGS_FILE" ]; then
+    echo -e "${YELLOW}⚠️  No backup found - surgically removing Islands Dark settings...${NC}"
+    if command -v jq &> /dev/null; then
+        CLEANED=$(jq --arg theme "$PREV_THEME" --arg icon "$PREV_ICON_THEME" '
+            del(."// Islands Dark Settings v0.0.3") |
+            del(."// Islands Dark Settings v0.0.2") |
+            del(."custom-ui-style.stylesheet") |
+            del(."custom-ui-style.font") |
+            del(."chat.viewSessions.orientation") |
+            . + {"workbench.colorTheme": $theme} |
+            if $icon != "" then . + {"workbench.iconTheme": $icon} else del(."workbench.iconTheme") end
+        ' "$SETTINGS_FILE" 2>/dev/null)
+        if [ -n "$CLEANED" ]; then
+            echo "$CLEANED" > "$SETTINGS_FILE"
+            echo -e "${GREEN}✓ Islands Dark settings removed, previous theme restored${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Could not modify settings - please update manually${NC}"
+        fi
+    else
+        echo -e "${YELLOW}⚠️  jq not found - please manually remove Islands Dark settings${NC}"
+    fi
+elif [ "$RESTORED" = false ]; then
+    echo -e "${YELLOW}⚠️  No settings.json found${NC}"
 fi
 
-# Step 2: Disable Custom UI Style
+# Step 2: Remove Islands Dark theme extension
 echo ""
-echo "🔧 Step 2: Disabling Custom UI Style..."
-echo -e "${YELLOW}   Please disable Custom UI Style manually:${NC}"
-echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
-echo "   2. Run 'Custom UI Style: Disable'"
-echo "   3. VS Code will reload"
-
-# Step 3: Remove theme extension
-echo ""
-echo "🗑️  Step 3: Removing Islands Dark theme extension..."
+echo "🗑️  Step 2: Removing Islands Dark theme extension..."
 EXT_DIR="$HOME/.vscode/extensions/bwya77.islands-dark-1.0.0"
 if [ -d "$EXT_DIR" ] || [ -L "$EXT_DIR" ]; then
     rm -rf "$EXT_DIR"
-    echo -e "${GREEN}✓ Theme extension removed${NC}"
+    echo -e "${GREEN}✓ Theme extension directory removed${NC}"
 else
     echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
 fi
 
-# Step 4: Uninstall extension via VS Code CLI
-echo ""
-echo "📋 Step 4: Uninstalling extension from VS Code..."
-if command -v code &> /dev/null; then
-    if code --uninstall-extension bwya77.islands-dark --force 2>/dev/null; then
-        echo -e "${GREEN}✓ Extension uninstalled via VS Code CLI${NC}"
-    else
-        echo -e "${YELLOW}⚠️  Extension not installed (or already removed)${NC}"
-    fi
-else
-    echo -e "${YELLOW}⚠️  VS Code CLI not found - extension directory was already removed in Step 3${NC}"
+if [ "$HAS_CLI" = true ]; then
+    code --uninstall-extension bwya77.islands-dark --force 2>/dev/null && \
+        echo -e "${GREEN}✓ Extension uninstalled via VS Code CLI${NC}" || true
 fi
 
-# Step 5: Change theme
+# Step 3: Handle Custom UI Style extension
 echo ""
-echo "🎨 Step 5: Change your color theme..."
-echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
-echo "   2. Search for 'Preferences: Color Theme'"
-echo "   3. Select your preferred theme"
+echo "🔧 Step 3: Handling Custom UI Style extension..."
+
+if [ "$CUI_WAS_INSTALLED" = "true" ]; then
+    echo -e "${GREEN}✓ Custom UI Style was installed before Islands Dark - leaving it installed${NC}"
+    echo "   The Islands Dark CSS rules have been removed from your settings."
+else
+    if [ "$HAS_CLI" = true ]; then
+        code --uninstall-extension subframe7536.custom-ui-style --force 2>/dev/null && \
+            echo -e "${GREEN}✓ Custom UI Style extension uninstalled${NC}" || \
+            echo -e "${YELLOW}⚠️  Custom UI Style may already be removed${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Please uninstall Custom UI Style manually from VS Code Extensions${NC}"
+    fi
+fi
+
+# Step 4: Remove fonts that we installed
+echo ""
+echo "🔤 Step 4: Removing installed fonts..."
+
+if [ "$HAS_STATE" = true ] && command -v jq &> /dev/null; then
+    REMOVED_COUNT=0
+    for fname in $(jq -r '.fonts | keys[]' "$STATE_FILE" 2>/dev/null); do
+        WAS_PRESENT=$(jq -r ".fonts.\"$fname\".wasPresentBeforeInstall" "$STATE_FILE" 2>/dev/null)
+        FONT_PATH=$(jq -r ".fonts.\"$fname\".installedPath" "$STATE_FILE" 2>/dev/null)
+        if [ "$WAS_PRESENT" = "false" ] && [ -n "$FONT_PATH" ] && [ -f "$FONT_PATH" ]; then
+            rm -f "$FONT_PATH"
+            REMOVED_COUNT=$((REMOVED_COUNT + 1))
+        fi
+    done
+    if [ "$REMOVED_COUNT" -gt 0 ]; then
+        echo -e "${GREEN}✓ $REMOVED_COUNT font(s) removed${NC}"
+        fc-cache -f 2>/dev/null || true
+    else
+        echo "   No fonts to remove (all were pre-existing)"
+    fi
+else
+    echo -e "${YELLOW}⚠️  No font state found - skipping font removal${NC}"
+    echo "   You can manually remove Bear Sans UI fonts if needed"
+fi
+
+# Step 5: Clean up state and backup files
+echo ""
+echo "🧹 Step 5: Cleaning up..."
+
+if [ -f "$STATE_FILE" ]; then
+    rm -f "$STATE_FILE"
+    echo "   State file removed"
+fi
+
+# Clean up backup files
+BACKUP_COUNT=$(ls "$SETTINGS_DIR"/settings.json.pre-islands-dark* 2>/dev/null | wc -l)
+if [ "$BACKUP_COUNT" -gt 0 ]; then
+    rm -f "$SETTINGS_DIR"/settings.json.pre-islands-dark*
+    echo "   $BACKUP_COUNT backup file(s) removed"
+fi
+
+# Step 6: Reload VS Code
+echo ""
+echo "🔄 Step 6: Reloading VS Code..."
+
+if [ "$HAS_CLI" = true ]; then
+    code --reload-window 2>/dev/null || code . 2>/dev/null || true
+    echo -e "${GREEN}✓ VS Code reload triggered${NC}"
+else
+    echo -e "${YELLOW}⚠️  Please restart VS Code manually to complete the uninstall${NC}"
+fi
 
 echo ""
 echo -e "${GREEN}✓ Islands Dark has been uninstalled!${NC}"
 echo ""
-echo "   Reload VS Code to complete the process."
+echo -e "${YELLOW}Note: If you see CSS artifacts, open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)${NC}"
+echo -e "${YELLOW}and run 'Custom UI Style: Disable' to clean up injected styles.${NC}"
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,14 +20,19 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
-BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
 
-if [ -f "$BACKUP_FILE" ]; then
-    cp "$BACKUP_FILE" "$SETTINGS_FILE"
+# Look for timestamped backups first, then the legacy backup name
+LATEST_BACKUP=""
+if [ -d "$SETTINGS_DIR" ]; then
+    LATEST_BACKUP=$(ls -t "$SETTINGS_DIR"/settings.json.pre-islands-dark* 2>/dev/null | head -1)
+fi
+
+if [ -n "$LATEST_BACKUP" ] && [ -f "$LATEST_BACKUP" ]; then
+    cp "$LATEST_BACKUP" "$SETTINGS_FILE"
     echo -e "${GREEN}✓ Settings restored from backup${NC}"
-    echo "   Backup file: $BACKUP_FILE"
+    echo "   Backup file: $LATEST_BACKUP"
 else
-    echo -e "${YELLOW}⚠️  No backup found at $BACKUP_FILE${NC}"
+    echo -e "${YELLOW}⚠️  No backup found${NC}"
     echo "   You may need to manually update your VS Code settings."
 fi
 
@@ -50,35 +55,17 @@ else
     echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
 fi
 
-# Step 4: Remove extension from extensions.json
+# Step 4: Uninstall extension via VS Code CLI
 echo ""
-echo "📋 Step 4: Unregistering extension..."
-if command -v node &> /dev/null; then
-    node << 'UNREGISTER_SCRIPT'
-const fs = require('fs');
-const path = require('path');
-
-const extJsonPath = path.join(process.env.HOME, '.vscode', 'extensions', 'extensions.json');
-if (fs.existsSync(extJsonPath)) {
-    try {
-        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
-        const before = extensions.length;
-        extensions = extensions.filter(e =>
-            e.identifier?.id !== 'bwya77.islands-dark' &&
-            e.identifier?.id !== 'your-publisher-name.islands-dark'
-        );
-        if (extensions.length < before) {
-            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
-            console.log('Extension unregistered');
-        } else {
-            console.log('Extension was not registered');
-        }
-    } catch (e) {
-        console.log('Could not update extensions.json');
-    }
-}
-UNREGISTER_SCRIPT
-    echo -e "${GREEN}✓ Extension unregistered${NC}"
+echo "📋 Step 4: Uninstalling extension from VS Code..."
+if command -v code &> /dev/null; then
+    if code --uninstall-extension bwya77.islands-dark --force 2>/dev/null; then
+        echo -e "${GREEN}✓ Extension uninstalled via VS Code CLI${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Extension not installed (or already removed)${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠️  VS Code CLI not found - extension directory was already removed in Step 3${NC}"
 fi
 
 # Step 5: Change theme


### PR DESCRIPTION
## Summary

The install scripts now properly back up the full pre-install state, and the uninstall scripts perform a complete automated revert — returning VS Code to exactly how it was before Islands Dark was installed.

## Install Script Changes (`install.ps1`, `install.sh`)

**New: State file (`.islands-dark-state.json`)** saved on first install to the VS Code User settings directory:

```json
{
  "previousColorTheme": "One Dark Pro",
  "previousIconTheme": "material-icon-theme",
  "customUiStyleWasInstalled": false,
  "settingsBackupPath": "...settings.json.pre-islands-dark.20240115-103000",
  "fonts": {
    "BearSansUI-Regular.otf": {
      "wasPresentBeforeInstall": false,
      "installedPath": "..."
    }
  },
  "installedAt": "2024-01-15T10:30:00Z"
}
```

- **Only created on first install** — re-running the installer won't overwrite the original state
- Records the exact backup file path so uninstall restores the right one
- Tracks per-font pre-existence to avoid removing fonts the user already had
- Records whether Custom UI Style was already installed

## Uninstall Script Changes (`uninstall.ps1`, `uninstall.sh`)

Complete automated revert in 6 steps:

| Step | What it does |
|------|-------------|
| 1 | Restores `settings.json` from the exact original backup (or surgically removes Islands Dark keys if no backup exists) |
| 2 | Removes the Islands Dark theme extension (directory + CLI uninstall) |
| 3 | Uninstalls Custom UI Style **only if the installer added it** (leaves it alone if user had it before) |
| 4 | Removes only fonts that weren't present before install |
| 5 | Cleans up state file and backup files |
| 6 | Automatically reloads VS Code |

**Surgical fallback** (when no backup exists): Instead of leaving the user stuck, the uninstall script removes only the Islands Dark-specific keys from `settings.json` and restores the previous color theme and icon theme from the state file.

## What changed from the old uninstall

| Before | After |
|--------|-------|
| ❌ Told user to manually disable Custom UI Style | ✅ Auto-uninstalls if we installed it |
| ❌ Told user to manually change color theme | ✅ Restores previous theme automatically |
| ❌ Didn't remove fonts | ✅ Removes only fonts we added |
| ❌ Didn't reload VS Code | ✅ Automatically reloads |
| ❌ No fallback if no backup existed | ✅ Surgical key removal fallback |
| ❌ Could restore wrong backup after reinstalls | ✅ Restores exact original backup via state file |