### PR TITLE
feat: add Antigravity IDE support on macOS/Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           cp install.sh uninstall.sh bootstrap.sh "$BUNDLE_DIR/" 2>/dev/null || true
           cp install.ps1 uninstall.ps1 bootstrap.ps1 "$BUNDLE_DIR/" 2>/dev/null || true
           cp install-cursor.sh uninstall-cursor.sh bootstrap-cursor.sh "$BUNDLE_DIR/" 2>/dev/null || true
+          cp install-antigravity.sh uninstall-antigravity.sh bootstrap-antigravity.sh "$BUNDLE_DIR/" 2>/dev/null || true
 
           # Make scripts executable
           chmod +x "$BUNDLE_DIR"/*.sh 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -150,6 +150,36 @@ To uninstall:
 ./uninstall-cursor.sh
 ```
 
+## Antigravity (VS Code fork)
+
+### One-Liner Install (Recommended)
+
+The fastest way to install:
+
+#### macOS/Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-antigravity.sh | bash
+```
+
+#### Manual Clone Install (Antigravity, macOS/Linux)
+
+```bash
+git clone https://github.com/bwya77/vscode-dark-islands.git islands-dark
+cd islands-dark
+./install-antigravity.sh
+```
+
+The Antigravity installer is a parallel of `install.sh` that targets Antigravity-specific paths (`~/.antigravity-ide/extensions/`, `~/Library/Application Support/Antigravity IDE/User/` on macOS, `~/.config/Antigravity IDE/User/` on Linux) and uses the `agy-ide` CLI instead of `code`. 
+
+> **Note:** Older deprecated Antigravity versions (<2.0) used legacy config paths, which are not currently supported. If you use an older version, manually back up your settings, install the theme yourself, and copy the relevant parts of `settings.json` into your Antigravity settings.
+
+To uninstall:
+
+```bash
+./uninstall-antigravity.sh
+```
+
 ### Manual Installation
 
 If you prefer to install manually, follow these steps:
@@ -335,6 +365,13 @@ irm https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/uninstall.
 # If you still have the repo cloned:
 cd islands-dark
 ./uninstall-cursor.sh
+```
+
+**Antigravity (macOS/Linux):*
+```bash
+# If you still have the repo cloned:
+cd islands-dark
+./uninstall-antigravity.sh
 ```
 
 The uninstall script will:

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ cd islands-dark
 ./uninstall-cursor.sh
 ```
 
-**Antigravity (macOS/Linux):*
+**Antigravity (macOS/Linux):**
 ```bash
 # If you still have the repo cloned:
 cd islands-dark

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cd islands-dark
 ./install-antigravity.sh
 ```
 
-The Antigravity installer is a parallel of `install.sh` that targets Antigravity-specific paths (`~/.antigravity-ide/extensions/`, `~/Library/Application Support/Antigravity IDE/User/` on macOS, `~/.config/Antigravity IDE/User/` on Linux) and uses the `agy-ide` CLI instead of `code`. 
+The Antigravity installer is a parallel of `install.sh` that targets Antigravity-specific paths (`~/.antigravity-ide/extensions/`, `~/Library/Application Support/Antigravity IDE/User/` on macOS, `~/.config/Antigravity IDE/User/` on Linux) and uses the `agy-ide` CLI instead of `code`.
 
 > **Note:** Older deprecated Antigravity versions (<2.0) used legacy config paths, which are not currently supported. If you use an older version, manually back up your settings, install the theme yourself, and copy the relevant parts of `settings.json` into your Antigravity settings.
 

--- a/bootstrap-antigravity.sh
+++ b/bootstrap-antigravity.sh
@@ -18,7 +18,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     OS="Linux"
 else
-    OS="Linux"
+    OS="Unknown"
+fi
+
+if [[ "$OS" == "Unknown" ]]; then
+    echo "⚠️  Automatic installation not supported for this OS"
+    echo "   Detected OSTYPE: $OSTYPE"
+    exit 1
 fi
 
 echo "📥 Step 1: Downloading Islands Dark..."
@@ -51,13 +57,17 @@ fi
 
 echo ""
 echo "🧹 Step 3: Cleaning up..."
-read -p "   Remove temporary files? (y/n) " -n 1 -r
-echo ""
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    rm -rf "$INSTALL_DIR"
-    echo "✓ Temporary files removed"
+if [ -t 0 ]; then
+    read -p "   Remove temporary files? (y/n) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf "$INSTALL_DIR"
+        echo "✓ Temporary files removed"
+    else
+        echo "   Files kept at: $INSTALL_DIR"
+    fi
 else
-    echo "   Files kept at: $INSTALL_DIR"
+    echo "   Non-interactive shell detected; keeping temporary files at: $INSTALL_DIR"
 fi
 
 echo ""

--- a/bootstrap-antigravity.sh
+++ b/bootstrap-antigravity.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+# Islands Dark Theme Bootstrap Installer for Antigravity IDE
+# One-liner: curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-antigravity.sh | bash
+
+echo "🏝️  Islands Dark Theme Bootstrap Installer (Antigravity IDE)"
+echo "==================================================="
+echo ""
+
+REPO_URL="https://github.com/bwya77/vscode-dark-islands.git"
+INSTALL_DIR="$HOME/.islands-dark-temp"
+
+# Detect OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    OS="macOS"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    OS="Linux"
+else
+    OS="Linux"
+fi
+
+echo "📥 Step 1: Downloading Islands Dark..."
+echo "   Repository: $REPO_URL"
+
+# Remove old temp directory if exists
+rm -rf "$INSTALL_DIR"
+
+# Clone repository
+BRANCH="main"
+if ! git clone "$REPO_URL" "$INSTALL_DIR" --quiet --branch "$BRANCH"; then
+    echo "❌ Failed to download Islands Dark"
+    exit 1
+fi
+
+echo "✓ Downloaded successfully!"
+echo ""
+
+echo "🚀 Step 2: Running Antigravity IDE installer..."
+echo ""
+
+if [[ "$OS" == "macOS" ]] || [[ "$OS" == "Linux" ]]; then
+    cd "$INSTALL_DIR"
+    bash install-antigravity.sh
+else
+    echo "⚠️  Automatic installation not supported for this OS"
+    echo "   Please manually run: cd $INSTALL_DIR && ./install-antigravity.sh"
+    exit 1
+fi
+
+echo ""
+echo "🧹 Step 3: Cleaning up..."
+read -p "   Remove temporary files? (y/n) " -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    rm -rf "$INSTALL_DIR"
+    echo "✓ Temporary files removed"
+else
+    echo "   Files kept at: $INSTALL_DIR"
+fi
+
+echo ""
+echo -e "🎉 Done! Enjoy your Islands Dark theme on Antigravity IDE!"

--- a/install-antigravity.sh
+++ b/install-antigravity.sh
@@ -106,18 +106,36 @@ fi
 mkdir -p "$SETTINGS_DIR"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
-# Backup existing settings if they exist
+# Backup existing settings if they exist, then merge
 if [ -f "$SETTINGS_FILE" ]; then
     BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
     cp "$SETTINGS_FILE" "$BACKUP_FILE"
     echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
     echo "   $BACKUP_FILE"
     echo "   You can restore your old settings from this file if needed."
-fi
 
-# Copy Islands Dark settings
-cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
-echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+    if command -v jq &> /dev/null; then
+        # Merge: user's non-theme settings are preserved, Islands Dark theme keys win
+        # This ensures updated fixes are applied while keeping user customizations
+        if MERGED=$(jq -s '.[0] * .[1]' "$SETTINGS_FILE" "$SCRIPT_DIR/settings.json" 2>/dev/null); then
+            echo "$MERGED" > "$SETTINGS_FILE"
+            echo -e "${GREEN}✓ Settings merged (your non-theme settings preserved, theme settings updated)${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Could not parse existing settings.json - leaving it untouched${NC}"
+            echo "   Your backup is at: $BACKUP_FILE"
+            echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        fi
+    else
+        echo -e "${YELLOW}⚠️  jq not found - cannot merge settings safely${NC}"
+        echo "   Your backup is at: $BACKUP_FILE"
+        echo "   To apply Islands Dark settings, manually merge from: $SCRIPT_DIR/settings.json"
+        echo "   Or install jq (https://jqlang.github.io/jq/) and re-run this script"
+    fi
+else
+    # No existing settings - just copy
+    cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+fi
 
 echo ""
 echo "🚀 Step 5: Enabling Custom UI Style..."

--- a/install-antigravity.sh
+++ b/install-antigravity.sh
@@ -39,13 +39,20 @@ echo -e "${GREEN}✓ Antigravity IDE installation found${NC}"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PACKAGE_VERSION=$(awk -F'"' '/"version"[[:space:]]*:/ { print $4; exit }' "$SCRIPT_DIR/package.json")
+if [ -z "$PACKAGE_VERSION" ]; then
+    echo -e "${RED}❌ Could not read theme version from package.json${NC}"
+    exit 1
+fi
 
 echo ""
 echo "📦 Step 1: Installing Islands Dark theme extension..."
 
 # Install by copying to Antigravity IDE extensions directory
-EXT_DIR="$HOME/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0"
-rm -rf "$EXT_DIR"
+EXT_BASE="$HOME/.antigravity-ide/extensions"
+EXT_DIR="$EXT_BASE/bwya77.islands-dark-$PACKAGE_VERSION"
+mkdir -p "$EXT_BASE"
+rm -rf "$EXT_BASE"/bwya77.islands-dark-*
 mkdir -p "$EXT_DIR"
 cp "$SCRIPT_DIR/package.json" "$EXT_DIR/"
 cp -r "$SCRIPT_DIR/themes" "$EXT_DIR/"
@@ -55,13 +62,6 @@ if [ -d "$EXT_DIR/themes" ]; then
 else
     echo -e "${RED}❌ Failed to install theme extension${NC}"
     exit 1
-fi
-
-# Remove extensions.json so Antigravity IDE rebuilds it cleanly on next launch
-EXT_JSON="$HOME/.antigravity-ide/extensions/extensions.json"
-if [ -f "$EXT_JSON" ]; then
-    rm -f "$EXT_JSON"
-    echo -e "${GREEN}✓ Cleared extensions.json (Antigravity IDE will rebuild it)${NC}"
 fi
 
 echo ""

--- a/install-antigravity.sh
+++ b/install-antigravity.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -e
+
+
+echo "🏝️  Islands Dark Theme Installer for Antigravity IDE (macOS/Linux)"
+echo "=================================================================="
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if agy-ide command is available
+if ! command -v agy-ide &> /dev/null; then
+    echo -e "${RED}❌ Error: Antigravity IDE CLI (agy-ide) not found!${NC}"
+    echo "Please install Antigravity IDE and make sure 'agy-ide' command is in your PATH."
+    echo "You can do this by:"
+    echo "  1. Open Antigravity IDE"
+    echo "  2. Press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Linux)"
+    echo "  3. Type 'Shell Command: Install agy-ide command in PATH'"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Antigravity IDE CLI found (agy-ide)${NC}"
+
+# Antigravity-specific safety check: Ensure Antigravity IDE should also have its product data directory initialized.
+ANTIGRAVITY_IDE_DIR="$HOME/.gemini/antigravity-ide"
+if [ ! -d "$ANTIGRAVITY_IDE_DIR" ]; then
+    echo -e "${RED}❌ Error: Antigravity IDE directory not found!${NC}"
+    echo "   Expected location: $ANTIGRAVITY_IDE_DIR"
+    echo "   Please ensure Antigravity IDE is installed and has been run at least once."
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Antigravity IDE installation found${NC}"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo ""
+echo "📦 Step 1: Installing Islands Dark theme extension..."
+
+# Install by copying to Antigravity IDE extensions directory
+EXT_DIR="$HOME/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0"
+rm -rf "$EXT_DIR"
+mkdir -p "$EXT_DIR"
+cp "$SCRIPT_DIR/package.json" "$EXT_DIR/"
+cp -r "$SCRIPT_DIR/themes" "$EXT_DIR/"
+
+if [ -d "$EXT_DIR/themes" ]; then
+    echo -e "${GREEN}✓ Theme extension installed to $EXT_DIR${NC}"
+else
+    echo -e "${RED}❌ Failed to install theme extension${NC}"
+    exit 1
+fi
+
+# Remove extensions.json so Antigravity IDE rebuilds it cleanly on next launch
+EXT_JSON="$HOME/.antigravity-ide/extensions/extensions.json"
+if [ -f "$EXT_JSON" ]; then
+    rm -f "$EXT_JSON"
+    echo -e "${GREEN}✓ Cleared extensions.json (Antigravity IDE will rebuild it)${NC}"
+fi
+
+echo ""
+echo "🔧 Step 2: Installing Custom UI Style extension..."
+if agy-ide --install-extension subframe7536.custom-ui-style --force; then
+    echo -e "${GREEN}✓ Custom UI Style extension installed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Could not install Custom UI Style extension automatically${NC}"
+    echo "   Please install it manually from the Extensions marketplace in Antigravity IDE"
+fi
+
+echo ""
+echo "🔤 Step 3: Installing Bear Sans UI fonts..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    FONT_DIR="$HOME/Library/Fonts"
+    echo "   Installing fonts to: $FONT_DIR"
+    cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
+    echo -e "${GREEN}✓ Fonts installed to Font Book${NC}"
+    echo "   Note: You may need to restart applications to use the new fonts"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux
+    FONT_DIR="$HOME/.local/share/fonts"
+    mkdir -p "$FONT_DIR"
+    echo "   Installing fonts to: $FONT_DIR"
+    cp "$SCRIPT_DIR/fonts/"*.otf "$FONT_DIR/" 2>/dev/null || true
+    fc-cache -f 2>/dev/null || true
+    echo -e "${GREEN}✓ Fonts installed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Could not detect OS type for automatic font installation${NC}"
+    echo "   Please manually install the fonts from the 'fonts/' folder"
+fi
+
+echo ""
+echo "⚙️  Step 4: Applying Antigravity IDE settings..."
+
+SETTINGS_DIR="$HOME/.config/Antigravity IDE/User"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SETTINGS_DIR="$HOME/Library/Application Support/Antigravity IDE/User"
+fi
+
+mkdir -p "$SETTINGS_DIR"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+# Backup existing settings if they exist
+if [ -f "$SETTINGS_FILE" ]; then
+    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+    cp "$SETTINGS_FILE" "$BACKUP_FILE"
+    echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
+    echo "   $BACKUP_FILE"
+    echo "   You can restore your old settings from this file if needed."
+fi
+
+# Copy Islands Dark settings
+cp "$SCRIPT_DIR/settings.json" "$SETTINGS_FILE"
+echo -e "${GREEN}✓ Islands Dark settings applied${NC}"
+
+echo ""
+echo "🚀 Step 5: Enabling Custom UI Style..."
+echo "   Antigravity IDE will reload after applying changes..."
+
+# Create a flag file to indicate first run
+FIRST_RUN_FILE="$SCRIPT_DIR/.islands_dark_first_run_antigravity"
+if [ ! -f "$FIRST_RUN_FILE" ]; then
+    touch "$FIRST_RUN_FILE"
+    echo ""
+    echo -e "${YELLOW}📝 Important Notes for Antigravity IDE users:${NC}"
+    echo "   • IBM Plex Mono and FiraCode Nerd Font Mono need to be installed separately"
+    echo "   • After Antigravity IDE reloads, you may see a 'corrupt installation' warning"
+    echo "   • This is expected — click the gear icon and select 'Don't Show Again'"
+    echo "   • To activate the theme in Antigravity IDE, use the theme picker (Cmd/Ctrl+K Cmd/Ctrl+T)"
+    echo "   • After every Antigravity IDE update, re-run 'Custom UI Style: Reload' to reapply"
+    echo ""
+    if [ -t 0 ]; then
+        read -p "Press Enter to continue and reload Antigravity IDE..."
+    fi
+fi
+
+echo "   Applying CSS customizations..."
+
+echo -e "${GREEN}✓ Setup complete!${NC}"
+echo ""
+echo "🎉 Islands Dark theme has been installed for Antigravity IDE!"
+echo "   Antigravity IDE will now reload to apply the custom UI style."
+echo ""
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    osascript -e 'display notification "Islands Dark theme installed for Antigravity IDE!" with title "🏝️ Islands Dark"' 2>/dev/null || true
+fi
+
+echo "   Reloading Antigravity-IDE..."
+agy-ide --reload-window 2>/dev/null || agy-ide . 2>/dev/null || true
+
+echo ""
+echo -e "${GREEN}Done! 🏝️${NC}"

--- a/install-antigravity.sh
+++ b/install-antigravity.sh
@@ -108,7 +108,8 @@ SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
 # Backup existing settings if they exist, then merge
 if [ -f "$SETTINGS_FILE" ]; then
-    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+    TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+    BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark.$TIMESTAMP"
     cp "$SETTINGS_FILE" "$BACKUP_FILE"
     echo -e "${YELLOW}⚠️  Existing settings.json backed up to:${NC}"
     echo "   $BACKUP_FILE"

--- a/tests/bootstrap-antigravity.sh
+++ b/tests/bootstrap-antigravity.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! grep -q 'Automatic installation not supported for this OS' "$repo_root/bootstrap-antigravity.sh"; then
+  echo "ERROR: bootstrap script is missing an explicit unsupported-OS branch for non-darwin/non-linux systems" >&2
+  exit 1
+fi
+
+if grep -q 'read -p "   Remove temporary files? (y/n) "' "$repo_root/bootstrap-antigravity.sh" && ! grep -q 'if \[ -t 0 \]; then' "$repo_root/bootstrap-antigravity.sh"; then
+  echo "ERROR: bootstrap cleanup prompt appears to be unconditional" >&2
+  exit 1
+fi
+
+echo "PASS"

--- a/tests/install-antigravity.sh
+++ b/tests/install-antigravity.sh
@@ -6,11 +6,13 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp_home="$(mktemp -d)"
 tmp_bin="$tmp_home/bin"
 output_file="$tmp_home/install-antigravity.out"
+settings_dir="$tmp_home/.config/Antigravity IDE/User"
+settings_file="$settings_dir/settings.json"
 
 cleanup() { rm -rf "$tmp_home"; }
 trap cleanup EXIT
 
-mkdir -p "$tmp_bin" "$tmp_home/.antigravity-ide/extensions" "$tmp_home/.gemini/antigravity-ide"
+mkdir -p "$tmp_bin" "$tmp_home/.antigravity-ide/extensions" "$tmp_home/.gemini/antigravity-ide" "$settings_dir"
 
 cat >"$tmp_bin/agy-ide" <<'EOF'
 #!/bin/bash
@@ -18,15 +20,62 @@ exit 0
 EOF
 chmod +x "$tmp_bin/agy-ide"
 
-printf '%s\n' '[{"identifier":{"id":"other.extension"},"version":"1.2.3"}]' > "$tmp_home/.antigravity-ide/extensions/extensions.json"
-
-if HOME="$tmp_home" PATH="$tmp_bin:$PATH" OSTYPE=linux-gnu /bin/bash "$repo_root/install-antigravity.sh" >"$output_file" 2>&1; then
-  :
-else
-  echo "install-antigravity.sh exited nonzero" >&2
-  cat "$output_file" >&2
+cat >"$tmp_bin/jq" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "$1" != "-s" ]; then
   exit 1
 fi
+python3 - "$3" "$4" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as left_file:
+    merged = json.load(left_file)
+with open(sys.argv[2], encoding="utf-8") as right_file:
+    merged.update(json.load(right_file))
+print(json.dumps(merged, indent=2))
+PY
+EOF
+chmod +x "$tmp_bin/jq"
+
+cat >"$tmp_bin/date" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" = "+%Y%m%d-%H%M%S" ]; then
+  counter_file="$HOME/.date-counter"
+  counter=0
+  if [ -f "$counter_file" ]; then
+    counter=$(cat "$counter_file")
+  fi
+  counter=$((counter + 1))
+  printf '%s' "$counter" > "$counter_file"
+  printf '20260613-12000%d\n' "$counter"
+else
+  /bin/date "$@"
+fi
+EOF
+chmod +x "$tmp_bin/date"
+
+printf '%s\n' '[{"identifier":{"id":"other.extension"},"version":"1.2.3"}]' > "$tmp_home/.antigravity-ide/extensions/extensions.json"
+
+cat >"$settings_file" <<'EOF'
+{
+  "editor.fontSize": 15,
+  "workbench.colorTheme": "Default Dark+"
+}
+EOF
+
+: > "$output_file"
+for run in 1 2; do
+  if HOME="$tmp_home" PATH="$tmp_bin:$PATH" OSTYPE=linux-gnu /bin/bash "$repo_root/install-antigravity.sh" >>"$output_file" 2>&1; then
+    :
+  else
+    echo "install-antigravity.sh run $run exited nonzero" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+done
 
 ext_dir="$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2"
 if [ ! -d "$ext_dir" ]; then
@@ -48,5 +97,37 @@ if command -v node >/dev/null 2>&1; then
     exit 1
   }
 fi
+
+python3 - "$settings_file" "$settings_dir" <<'PY'
+import glob
+import json
+import os
+import sys
+
+settings_file, settings_dir = sys.argv[1:3]
+with open(settings_file, encoding="utf-8") as file:
+    settings = json.load(file)
+
+if settings.get("editor.fontSize") != 15:
+    raise SystemExit("ERROR: existing user settings were not preserved")
+if settings.get("workbench.colorTheme") != "Islands Dark":
+    raise SystemExit("ERROR: Islands Dark theme settings were not applied")
+
+fixed_backup = settings_file + ".pre-islands-dark"
+if os.path.exists(fixed_backup):
+    raise SystemExit("ERROR: installer created fixed backup path instead of timestamped backup")
+
+backups = sorted(glob.glob(os.path.join(settings_dir, "settings.json.pre-islands-dark.*")))
+if len(backups) < 2:
+    raise SystemExit("ERROR: repeated installer runs did not create distinct timestamped backups")
+
+for backup in backups:
+    with open(backup, encoding="utf-8") as file:
+        backup_settings = json.load(file)
+    if backup_settings.get("workbench.colorTheme") == "Default Dark+" and backup_settings.get("editor.fontSize") == 15:
+        break
+else:
+    raise SystemExit("ERROR: original user settings were not preserved in a timestamped backup")
+PY
 
 echo "PASS"

--- a/tests/install-antigravity.sh
+++ b/tests/install-antigravity.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_home="$(mktemp -d)"
+tmp_bin="$tmp_home/bin"
+output_file="$tmp_home/install-antigravity.out"
+
+cleanup() { rm -rf "$tmp_home"; }
+trap cleanup EXIT
+
+mkdir -p "$tmp_bin" "$tmp_home/.antigravity-ide/extensions" "$tmp_home/.gemini/antigravity-ide"
+
+cat >"$tmp_bin/agy-ide" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$tmp_bin/agy-ide"
+
+printf '%s\n' '[{"identifier":{"id":"other.extension"},"version":"1.2.3"}]' > "$tmp_home/.antigravity-ide/extensions/extensions.json"
+
+if HOME="$tmp_home" PATH="$tmp_bin:$PATH" OSTYPE=linux-gnu /bin/bash "$repo_root/install-antigravity.sh" >"$output_file" 2>&1; then
+  :
+else
+  echo "install-antigravity.sh exited nonzero" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+ext_dir="$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2"
+if [ ! -d "$ext_dir" ]; then
+  echo "ERROR: expected package.json-derived extension dir at $ext_dir" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if [ ! -f "$tmp_home/.antigravity-ide/extensions/extensions.json" ]; then
+  echo "ERROR: extensions.json was deleted" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if command -v node >/dev/null 2>&1; then
+  node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); if (!Array.isArray(data) || !data.some(e => e.identifier?.id === 'other.extension')) process.exit(1);" "$tmp_home/.antigravity-ide/extensions/extensions.json" || {
+    echo "ERROR: unrelated extension entry was not preserved in extensions.json" >&2
+    cat "$output_file" >&2
+    exit 1
+  }
+fi
+
+echo "PASS"

--- a/tests/readme-antigravity.sh
+++ b/tests/readme-antigravity.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if grep -qx '\*\*Antigravity (macOS/Linux):\*' "$repo_root/README.md"; then
+  echo "ERROR: README has mismatched bold delimiters for Antigravity (macOS/Linux)" >&2
+  exit 1
+fi
+
+if ! grep -qx '\*\*Antigravity (macOS/Linux):\*\*' "$repo_root/README.md"; then
+  echo "ERROR: README is missing the expected bold Antigravity heading" >&2
+  exit 1
+fi
+
+echo "PASS"

--- a/tests/uninstall-antigravity-no-register.sh
+++ b/tests/uninstall-antigravity-no-register.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_home="$(mktemp -d)"
+output_file="$tmp_home/uninstall-no-register.out"
+
+cleanup() { rm -rf "$tmp_home"; }
+trap cleanup EXIT
+
+mkdir -p "$tmp_home/.config/Antigravity IDE/User" "$tmp_home/.antigravity-ide/extensions"
+
+if HOME="$tmp_home" OSTYPE=linux-gnu /bin/bash "$repo_root/uninstall-antigravity.sh" >"$output_file" 2>&1; then
+  :
+else
+  echo "uninstall-antigravity.sh exited nonzero" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if grep -q "✓ Extension unregistered" "$output_file"; then
+  echo "ERROR: green unregister line should not be printed when nothing was removed" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if ! grep -Eq "Extension was not registered|Could not update extensions\.json|No extensions\.json found|not found" "$output_file"; then
+  echo "ERROR: expected a neutral/warning unregister message" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+echo "PASS"

--- a/tests/uninstall-antigravity-regression.sh
+++ b/tests/uninstall-antigravity-regression.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_home="$(mktemp -d)"
+
+cleanup() { rm -rf "$tmp_home"; }
+trap cleanup EXIT
+
+mkdir -p "$tmp_home/.config/Antigravity IDE/User" "$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2" "$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0" "$tmp_home/.antigravity-ide/extensions/other.extension"
+
+printf '%s\n' '[{"identifier":{"id":"bwya77.islands-dark"}},{"identifier":{"id":"other.extension"}}]' > "$tmp_home/.antigravity-ide/extensions/extensions.json"
+
+HOME="$tmp_home" OSTYPE=linux-gnu /bin/bash "$repo_root/uninstall-antigravity.sh" >/dev/null 2>&1
+
+if [ -d "$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0" ] || [ -d "$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2" ]; then
+  echo "ERROR: matching Islands Dark extension dirs were not fully removed" >&2
+  exit 1
+fi
+
+if [ ! -d "$tmp_home/.antigravity-ide/extensions/other.extension" ]; then
+  echo "ERROR: unrelated extension dir was removed" >&2
+  exit 1
+fi
+
+echo "PASS"

--- a/tests/uninstall-antigravity.sh
+++ b/tests/uninstall-antigravity.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_home="$(mktemp -d)"
+output_file="$tmp_home/uninstall-antigravity.out"
+
+cleanup() {
+  rm -rf "$tmp_home"
+}
+trap cleanup EXIT
+
+settings_dir="$tmp_home/.config/Antigravity IDE/User"
+settings_file="$settings_dir/settings.json"
+backup_file="$settings_file.pre-islands-dark"
+ext_dir="$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2"
+ext_json="$tmp_home/.antigravity-ide/extensions/extensions.json"
+
+mkdir -p "$settings_dir" "$ext_dir" "$(dirname "$ext_json")"
+printf '%s\n' '{"workbench.colorTheme":"Islands Dark"}' > "$settings_file"
+printf '%s\n' '{"workbench.colorTheme":"Default Dark+"}' > "$backup_file"
+printf '%s\n' '[{"identifier":{"id":"bwya77.islands-dark"}},{"identifier":{"id":"other.extension"}}]' > "$ext_json"
+
+if HOME="$tmp_home" OSTYPE=linux-gnu /bin/bash "$repo_root/uninstall-antigravity.sh" >"$output_file" 2>&1; then
+  :
+else
+  echo "uninstall-antigravity.sh exited nonzero" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if [ "$(cat "$settings_file")" != '{"workbench.colorTheme":"Default Dark+"}' ]; then
+  echo "ERROR: settings.json was not restored from Antigravity backup" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if [ -e "$ext_dir" ]; then
+  echo "ERROR: Antigravity extension directory was not removed" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+if command -v node >/dev/null 2>&1; then
+  if node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(data.some(e => e.identifier?.id === 'bwya77.islands-dark') ? 1 : 0);" "$ext_json"; then
+    :
+  else
+    echo "ERROR: Antigravity extension was not removed from extensions.json" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+fi
+
+if ! grep -q "Islands Dark has been uninstalled from Antigravity IDE" "$output_file"; then
+  echo "ERROR: uninstall output did not mention Antigravity IDE completion" >&2
+  cat "$output_file" >&2
+  exit 1
+fi
+
+echo "PASS"

--- a/tests/uninstall-antigravity.sh
+++ b/tests/uninstall-antigravity.sh
@@ -13,14 +13,16 @@ trap cleanup EXIT
 
 settings_dir="$tmp_home/.config/Antigravity IDE/User"
 settings_file="$settings_dir/settings.json"
-backup_file="$settings_file.pre-islands-dark"
+backup_file="$settings_file.pre-islands-dark.20260613-120001"
+later_backup_file="$settings_file.pre-islands-dark.20260613-120002"
 ext_dir="$tmp_home/.antigravity-ide/extensions/bwya77.islands-dark-0.0.2"
 ext_json="$tmp_home/.antigravity-ide/extensions/extensions.json"
 
 mkdir -p "$settings_dir" "$ext_dir" "$(dirname "$ext_json")"
 printf '%s\n' '{"workbench.colorTheme":"Islands Dark"}' > "$settings_file"
 printf '%s\n' '{"workbench.colorTheme":"Default Dark+"}' > "$backup_file"
-printf '%s\n' '[{"identifier":{"id":"bwya77.islands-dark"}},{"identifier":{"id":"other.extension"}}]' > "$ext_json"
+printf '%s\n' '{"workbench.colorTheme":"Islands Dark"}' > "$later_backup_file"
+printf '%s\n' '[{"identifier":{"id":"bwya77.islands-dark"}},{"identifier":{"id":"your-publisher-name.islands-dark"}},{"identifier":{"id":"other.extension"}}]' > "$ext_json"
 
 if HOME="$tmp_home" OSTYPE=linux-gnu /bin/bash "$repo_root/uninstall-antigravity.sh" >"$output_file" 2>&1; then
   :
@@ -47,6 +49,14 @@ if command -v node >/dev/null 2>&1; then
     :
   else
     echo "ERROR: Antigravity extension was not removed from extensions.json" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  if node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.exit(data.some(e => e.identifier?.id === 'your-publisher-name.islands-dark') ? 0 : 1);" "$ext_json"; then
+    :
+  else
+    echo "ERROR: placeholder extension ID should not be removed from extensions.json" >&2
     cat "$output_file" >&2
     exit 1
   fi

--- a/uninstall-antigravity.sh
+++ b/uninstall-antigravity.sh
@@ -20,14 +20,28 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
-BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+LEGACY_BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+BACKUP_FILE=""
 
-if [ -f "$BACKUP_FILE" ]; then
+if [ -d "$SETTINGS_DIR" ]; then
+    for candidate in "$SETTINGS_DIR"/settings.json.pre-islands-dark.*; do
+        if [ -f "$candidate" ]; then
+            BACKUP_FILE="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ -n "$BACKUP_FILE" ] && [ -f "$BACKUP_FILE" ]; then
     cp "$BACKUP_FILE" "$SETTINGS_FILE"
     echo -e "${GREEN}✓ Settings restored from backup${NC}"
     echo "   Backup file: $BACKUP_FILE"
+elif [ -f "$LEGACY_BACKUP_FILE" ]; then
+    cp "$LEGACY_BACKUP_FILE" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Settings restored from backup${NC}"
+    echo "   Backup file: $LEGACY_BACKUP_FILE"
 else
-    echo -e "${YELLOW}⚠️  No backup found at $BACKUP_FILE${NC}"
+    echo -e "${YELLOW}⚠️  No Antigravity settings backup found${NC}"
     echo "   You may need to manually update your Antigravity IDE settings."
 fi
 
@@ -80,7 +94,7 @@ try {
         console.log('PARSE_ERROR');
         process.exit(1);
     }
-    const islandsDarkIds = new Set(['bwya77.islands-dark', 'your-publisher-name.islands-dark']);
+    const islandsDarkIds = new Set(['bwya77.islands-dark']);
     const before = extensions.length;
     extensions = extensions.filter(e => !islandsDarkIds.has(e?.identifier?.id));
     if (extensions.length < before) {

--- a/uninstall-antigravity.sh
+++ b/uninstall-antigravity.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e
+
+echo "🏝️  Islands Dark Theme Uninstaller for Antigravity IDE (macOS/Linux)"
+echo "==================================================================="
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Step 1: Restore old settings
+echo "⚙️  Step 1: Restoring Antigravity IDE settings..."
+SETTINGS_DIR="$HOME/.config/Antigravity IDE/User"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SETTINGS_DIR="$HOME/Library/Application Support/Antigravity IDE/User"
+fi
+
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+BACKUP_FILE="$SETTINGS_FILE.pre-islands-dark"
+
+if [ -f "$BACKUP_FILE" ]; then
+    cp "$BACKUP_FILE" "$SETTINGS_FILE"
+    echo -e "${GREEN}✓ Settings restored from backup${NC}"
+    echo "   Backup file: $BACKUP_FILE"
+else
+    echo -e "${YELLOW}⚠️  No backup found at $BACKUP_FILE${NC}"
+    echo "   You may need to manually update your Antigravity IDE settings."
+fi
+
+# Step 2: Disable Custom UI Style
+echo ""
+echo "🔧 Step 2: Disabling Custom UI Style..."
+echo -e "${YELLOW}   Please disable Custom UI Style manually:${NC}"
+echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
+echo "   2. Run 'Custom UI Style: Disable'"
+echo "   3. Antigravity IDE will reload"
+
+# Step 3: Remove theme extension
+echo ""
+echo "🗑️  Step 3: Removing Islands Dark theme extension..."
+EXT_DIR="$HOME/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0"
+if [ -d "$EXT_DIR" ] || [ -L "$EXT_DIR" ]; then
+    rm -rf "$EXT_DIR"
+    echo -e "${GREEN}✓ Theme extension removed${NC}"
+else
+    echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
+fi
+
+# Step 4: Remove extension from extensions.json
+echo ""
+echo "📋 Step 4: Unregistering extension..."
+if command -v node &> /dev/null; then
+    node << 'UNREGISTER_SCRIPT'
+const fs = require('fs');
+const path = require('path');
+
+const extJsonPath = path.join(process.env.HOME, '.antigravity-ide', 'extensions', 'extensions.json');
+if (fs.existsSync(extJsonPath)) {
+    try {
+        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
+        const before = extensions.length;
+        extensions = extensions.filter(e =>
+            e.identifier?.id !== 'bwya77.islands-dark' &&
+            e.identifier?.id !== 'your-publisher-name.islands-dark'
+        );
+        if (extensions.length < before) {
+            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
+            console.log('Extension unregistered');
+        } else {
+            console.log('Extension was not registered');
+        }
+    } catch (e) {
+        console.log('Could not update extensions.json');
+    }
+}
+UNREGISTER_SCRIPT
+    echo -e "${GREEN}✓ Extension unregistered${NC}"
+fi
+
+# Step 5: Change theme
+echo ""
+echo "🎨 Step 5: Change your color theme..."
+echo "   1. Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)"
+echo "   2. Search for 'Preferences: Color Theme'"
+echo "   3. Select your preferred theme"
+
+echo ""
+echo -e "${GREEN}✓ Islands Dark has been uninstalled from Antigravity IDE!${NC}"
+echo ""
+echo "   Reload Antigravity IDE to complete the process."
+echo ""

--- a/uninstall-antigravity.sh
+++ b/uninstall-antigravity.sh
@@ -42,43 +42,84 @@ echo "   3. Antigravity IDE will reload"
 # Step 3: Remove theme extension
 echo ""
 echo "🗑️  Step 3: Removing Islands Dark theme extension..."
-EXT_DIR="$HOME/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0"
-if [ -d "$EXT_DIR" ] || [ -L "$EXT_DIR" ]; then
-    rm -rf "$EXT_DIR"
-    echo -e "${GREEN}✓ Theme extension removed${NC}"
+EXT_BASE="$HOME/.antigravity-ide/extensions"
+if [ -d "$EXT_BASE" ] || [ -L "$EXT_BASE" ]; then
+    removed_any=false
+    for ext_dir in "$EXT_BASE"/bwya77.islands-dark-*; do
+        if [ -e "$ext_dir" ] || [ -L "$ext_dir" ]; then
+            rm -rf "$ext_dir"
+            removed_any=true
+        fi
+    done
+    if [ "$removed_any" = true ]; then
+        echo -e "${GREEN}✓ Theme extension removed${NC}"
+    else
+        echo -e "${YELLOW}⚠️  No Islands Dark extension directories found${NC}"
+    fi
 else
-    echo -e "${YELLOW}⚠️  Extension directory not found (may already be removed)${NC}"
+    echo -e "${YELLOW}⚠️  Extensions directory not found (may already be removed)${NC}"
 fi
 
 # Step 4: Remove extension from extensions.json
 echo ""
 echo "📋 Step 4: Unregistering extension..."
 if command -v node &> /dev/null; then
-    node << 'UNREGISTER_SCRIPT'
+    if UNREGISTER_RESULT=$(node << 'UNREGISTER_SCRIPT'
 const fs = require('fs');
 const path = require('path');
 
 const extJsonPath = path.join(process.env.HOME, '.antigravity-ide', 'extensions', 'extensions.json');
-if (fs.existsSync(extJsonPath)) {
-    try {
-        let extensions = JSON.parse(fs.readFileSync(extJsonPath, 'utf8'));
-        const before = extensions.length;
-        extensions = extensions.filter(e =>
-            e.identifier?.id !== 'bwya77.islands-dark' &&
-            e.identifier?.id !== 'your-publisher-name.islands-dark'
-        );
-        if (extensions.length < before) {
-            fs.writeFileSync(extJsonPath, JSON.stringify(extensions));
-            console.log('Extension unregistered');
-        } else {
-            console.log('Extension was not registered');
-        }
-    } catch (e) {
-        console.log('Could not update extensions.json');
+if (!fs.existsSync(extJsonPath)) {
+    console.log('NO_FILE');
+    process.exit(1);
+}
+try {
+    const raw = fs.readFileSync(extJsonPath, 'utf8');
+    let extensions = JSON.parse(raw);
+    if (!Array.isArray(extensions)) {
+        console.log('PARSE_ERROR');
+        process.exit(1);
     }
+    const islandsDarkIds = new Set(['bwya77.islands-dark', 'your-publisher-name.islands-dark']);
+    const before = extensions.length;
+    extensions = extensions.filter(e => !islandsDarkIds.has(e?.identifier?.id));
+    if (extensions.length < before) {
+        fs.writeFileSync(extJsonPath, JSON.stringify(extensions, null, 2) + '\n');
+        console.log('REMOVED');
+        process.exit(0);
+    } else {
+        console.log('NO_ENTRY');
+        process.exit(1);
+    }
+} catch (e) {
+    console.log('ERROR');
+    process.exit(1);
 }
 UNREGISTER_SCRIPT
-    echo -e "${GREEN}✓ Extension unregistered${NC}"
+    ); then
+        if [ "$UNREGISTER_RESULT" = "REMOVED" ]; then
+            echo -e "${GREEN}✓ Extension unregistered${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Unexpected unregister result: $UNREGISTER_RESULT${NC}"
+        fi
+    else
+        case "$UNREGISTER_RESULT" in
+            NO_FILE)
+                echo -e "${YELLOW}⚠️  No extensions.json found${NC}"
+                ;;
+            NO_ENTRY)
+                echo -e "${YELLOW}⚠️  Islands Dark was not registered${NC}"
+                ;;
+            PARSE_ERROR|ERROR)
+                echo -e "${YELLOW}⚠️  Could not update extensions.json${NC}"
+                ;;
+            *)
+                echo -e "${YELLOW}⚠️  Could not update extensions.json${NC}"
+                ;;
+        esac
+    fi
+else
+    echo -e "${YELLOW}⚠️  Node.js not found; cannot unregister extension automatically${NC}"
 fi
 
 # Step 5: Change theme


### PR DESCRIPTION
> [!NOTE]
> This PR addresses the reverted PR #153, which includes the most recent fixes:
> - `install-antigravity.sh` now merges Islands Dark settings into existing user settings instead of overwriting `settings.json`.
> - Existing settings backups now use timestamped filenames so repeated installer runs do not overwrite the original backup.
> - Removed the placeholder `your-publisher-name.islands-dark` extension ID from the Antigravity uninstaller cleanup list.

## Summary

[Antigravity IDE](https://antigravity.google/) is a VS Code fork with its own CLI, extension directory, and user settings paths. The existing `install.sh` / `bootstrap.sh` / `uninstall.sh` target VS Code paths and the `code` CLI, so Antigravity users cannot use the standard one-liner install flow.

This PR adds a parallel macOS/Linux install flow for Antigravity IDE without changing the existing VS Code install scripts. It fixes the addressed issues in #104 

Once merged, Antigravity users get the same one-line install experience:

```bash
curl -fsSL https://raw.githubusercontent.com/bwya77/vscode-dark-islands/main/bootstrap-antigravity.sh | bash
```

## What's added

| File | Purpose |
|---|---|
| `install-antigravity.sh` | Mirror of `install.sh` for Antigravity IDE — uses `~/.antigravity-ide/extensions/`, `~/Library/Application Support/Antigravity IDE/User/` on macOS, `~/.config/Antigravity IDE/User/` on Linux, and the `agy-ide` CLI |
| `bootstrap-antigravity.sh` | One-liner entry point — clones the repo and runs `install-antigravity.sh` |
| `uninstall-antigravity.sh` | Mirror of `uninstall-cursor.sh` for Antigravity IDE paths |
| `README.md` | Adds Antigravity install/uninstall instructions, supported config paths, and a legacy-version compatibility note |
| `.github/workflows/release.yml` | Includes the Antigravity scripts in release bundles |

## Antigravity-specific behavior

The Antigravity installer follows the same general flow as the existing Unix installer:

1. Copies the Islands Dark extension into Antigravity's extension directory:
   ```bash
   ~/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0
   ```

2. Installs Custom UI Style through the Antigravity CLI:
   ```bash
   agy-ide --install-extension subframe7536.custom-ui-style --force
   ```

3. Installs bundled fonts into the platform-specific font directory.

4. Applies Islands Dark settings to the Antigravity settings file:
   - macOS:
     ```bash
     ~/Library/Application Support/Antigravity IDE/User/settings.json
     ```
   - Linux:
     ```bash
     ~/.config/Antigravity IDE/User/settings.json
     ```

5. Backs up any existing Antigravity settings to:
   ```bash
   settings.json.pre-islands-dark
   ```

6. Reloads Antigravity IDE through:
   ```bash
   agy-ide --reload-window
   ```

## Compatibility note

Current Antigravity IDE versions use the `Antigravity IDE` config paths and the `agy-ide` CLI. Older deprecated Antigravity versions (`<2.0`) used legacy config paths, which this PR intentionally does not support.

The README documents that users on older versions should manually back up their settings, install the theme manually, and copy the relevant parts of `settings.json` into their Antigravity settings.

## Why this is a separate install flow

I kept this separate from the existing VS Code scripts for the same reason Cursor has its own flow: Antigravity has different runtime assumptions.

A separate script keeps the changes easy to review and avoids adding conditional branching to the existing VS Code installer. The VS Code install/uninstall behavior remains untouched.

## Test plan

- [x] `/bin/bash -n bootstrap-antigravity.sh install-antigravity.sh uninstall-antigravity.sh`
- [x] `git diff --check upstream/main...HEAD && git diff --check`
- [x] Local temp-home uninstall regression check passed:
  - restores `settings.json` from `settings.json.pre-islands-dark`
  - removes `~/.antigravity-ide/extensions/bwya77.islands-dark-1.0.0`
  - unregisters `bwya77.islands-dark` from Antigravity's `extensions.json`
- [x] Real Antigravity IDE install test on macOS 26 Tahoe
- [x] Real Linux install test on Ubuntu 22.04
