### PR TITLE
Backup and restore extensions.json during install/uninstall

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -105,8 +105,11 @@ if (Test-Path "$extDir\themes") {
 
 $extJson = Join-Path $extRoot "extensions.json"
 if (Test-Path $extJson) {
+    $extJsonBackup = "$extJson.pre-islands-dark.$(Get-Date -Format 'yyyyMMddHHmmss')"
+    Copy-Item $extJson $extJsonBackup -Force
     Remove-Item $extJson -Force
-    Write-Host "Cleared extensions.json ($editorName will rebuild it)" -ForegroundColor Green
+    Write-Host "Backed up extensions.json and cleared it ($editorName will rebuild it)" -ForegroundColor Green
+    Write-Host "   Backup: $extJsonBackup" -ForegroundColor DarkGray
 }
 
 Write-Host ""
@@ -295,6 +298,7 @@ if (-not (Test-Path $stateFile)) {
         previousIconTheme  = ""
         customUiStyleWasInstalled = $false
         settingsBackupPath = ""
+        extensionsJsonBackupPath = ""
         fonts = @{}
         installedAt = (Get-Date -Format "o")
     }
@@ -314,6 +318,11 @@ if (-not (Test-Path $stateFile)) {
             }
         } catch {}
         $state.settingsBackupPath = $backupFile
+    }
+
+    # Record extensions.json backup path
+    if ($extJsonBackup -and (Test-Path $extJsonBackup)) {
+        $state.extensionsJsonBackupPath = $extJsonBackup
     }
 
     # Check if Custom UI Style was already installed

--- a/install.sh
+++ b/install.sh
@@ -101,9 +101,13 @@ else
 fi
 
 EXT_JSON="$EXT_ROOT/extensions.json"
+EXT_JSON_BACKUP=""
 if [ -f "$EXT_JSON" ]; then
+    EXT_JSON_BACKUP="$EXT_JSON.pre-islands-dark.$(date +%Y%m%d%H%M%S)"
+    cp "$EXT_JSON" "$EXT_JSON_BACKUP"
     rm -f "$EXT_JSON"
-    echo -e "${GREEN}✓ Cleared extensions.json ($EDITOR_NAME will rebuild it)${NC}"
+    echo -e "${GREEN}✓ Backed up extensions.json and cleared it ($EDITOR_NAME will rebuild it)${NC}"
+    echo "   Backup: $EXT_JSON_BACKUP"
 fi
 
 echo ""
@@ -225,6 +229,7 @@ if [ ! -f "$STATE_FILE" ]; then
   "previousIconTheme": "$PREV_ICON_THEME",
   "customUiStyleWasInstalled": $CUI_WAS_INSTALLED,
   "settingsBackupPath": "$BACKUP_PATH",
+  "extensionsJsonBackupPath": "$EXT_JSON_BACKUP",
   "fonts": {${FONT_PRE_STATE}},
   "installedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -194,6 +194,20 @@ if ($codePath) {
 
 # Step 3: Handle Custom UI Style extension
 Write-Host ""
+Write-Host "Step 2b: Clearing extensions.json..."
+
+# Remove extensions.json so the editor rebuilds it from the extensions
+# actually on disk. Restoring the pre-install backup would lose any
+# extensions the user installed after Islands Dark.
+$extJson = Join-Path $extRoot "extensions.json"
+if (Test-Path $extJson) {
+    Remove-Item $extJson -Force
+    Write-Host "extensions.json removed ($editorName will rebuild it on next launch)" -ForegroundColor Green
+} else {
+    Write-Host "extensions.json not present (already clean)" -ForegroundColor DarkGray
+}
+
+Write-Host ""
 Write-Host "Step 3: Handling Custom UI Style extension..."
 
 if ($state -and $state.customUiStyleWasInstalled -eq $true) {
@@ -290,7 +304,16 @@ if (Test-Path $settingsDir) {
     $backupFiles = Get-ChildItem "$settingsDir\settings.json.pre-islands-dark*" -ErrorAction SilentlyContinue
     if ($backupFiles.Count -gt 0) {
         $backupFiles | Remove-Item -Force -ErrorAction SilentlyContinue
-        Write-Host "$($backupFiles.Count) backup file(s) removed" -ForegroundColor DarkGray
+        Write-Host "$($backupFiles.Count) settings backup file(s) removed" -ForegroundColor DarkGray
+    }
+}
+
+# Clean up extensions.json backup files
+if (Test-Path $extRoot) {
+    $extJsonBackups = Get-ChildItem "$extRoot\extensions.json.pre-islands-dark*" -ErrorAction SilentlyContinue
+    if ($extJsonBackups.Count -gt 0) {
+        $extJsonBackups | Remove-Item -Force -ErrorAction SilentlyContinue
+        Write-Host "$($extJsonBackups.Count) extensions.json backup file(s) removed" -ForegroundColor DarkGray
     }
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -184,6 +184,20 @@ fi
 
 # Step 3: Handle Custom UI Style extension
 echo ""
+echo "🔧 Step 2b: Clearing extensions.json..."
+
+# Remove extensions.json so the editor rebuilds it from the extensions
+# actually on disk. Restoring the pre-install backup would lose any
+# extensions the user installed after Islands Dark.
+EXT_JSON="$EXT_ROOT/extensions.json"
+if [ -f "$EXT_JSON" ]; then
+    rm -f "$EXT_JSON"
+    echo -e "${GREEN}✓ extensions.json removed ($EDITOR_NAME will rebuild it on next launch)${NC}"
+else
+    echo "   extensions.json not present (already clean)"
+fi
+
+echo ""
 echo "🔧 Step 3: Handling Custom UI Style extension..."
 
 if [ "$CUI_WAS_INSTALLED" = "true" ]; then
@@ -263,7 +277,14 @@ fi
 BACKUP_COUNT=$(ls "$SETTINGS_DIR"/settings.json.pre-islands-dark* 2>/dev/null | wc -l)
 if [ "$BACKUP_COUNT" -gt 0 ]; then
     rm -f "$SETTINGS_DIR"/settings.json.pre-islands-dark*
-    echo "   $BACKUP_COUNT backup file(s) removed"
+    echo "   $BACKUP_COUNT settings backup file(s) removed"
+fi
+
+# Clean up extensions.json backup files
+EXT_BACKUP_COUNT=$(ls "$EXT_ROOT"/extensions.json.pre-islands-dark* 2>/dev/null | wc -l)
+if [ "$EXT_BACKUP_COUNT" -gt 0 ]; then
+    rm -f "$EXT_ROOT"/extensions.json.pre-islands-dark*
+    echo "   $EXT_BACKUP_COUNT extensions.json backup file(s) removed"
 fi
 
 # Step 6: Reload editor


### PR DESCRIPTION
## Problem

The install scripts delete `extensions.json` without backing it up first (see [#140 comment](https://github.com/bwya77/vscode-dark-islands/issues/140#issuecomment-4758317538)). When users uninstall, their extensions are not restored because no backup exists to restore from.

## Changes

### Install scripts (`install.ps1`, `install.sh`)
- Back up `extensions.json` before clearing it (timestamped `.pre-islands-dark` backup)
- Record the backup path in the state file as `extensionsJsonBackupPath`

### Uninstall scripts (`uninstall.ps1`, `uninstall.sh`)
- New **Step 2b** restores `extensions.json` from the recorded backup path
- Falls back to the latest timestamped backup if the state file path is missing
- Cleanup step removes `extensions.json` backup files alongside settings backups

Fixes #140