### PR TITLE
Fix `nix run ...#vscodium` by filtering non-attrset entries in toCss

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
         customCssObj = settingsJson."custom-ui-style.stylesheet" or {};
 
         # Convert the JSON object into a valid CSS string
+        # Filters out non-attrset entries (e.g. JSON comment keys like "// ─── end ───": "")
         toCss = obj:
           builtins.concatStringsSep "\n" (
             pkgs.lib.mapAttrsToList (selector: rules:
@@ -70,7 +71,7 @@
                 pkgs.lib.mapAttrsToList (prop: value: "  ${prop}: ${value};") rules
               ) +
               "\n}"
-            ) obj
+            ) (pkgs.lib.filterAttrs (_: v: builtins.isAttrs v) obj)
           );
 
         customCssString = toCss customCssObj;


### PR DESCRIPTION
## Problem

`nix run github:bwya77/vscode-dark-islands#vscodium` (and `#vscode`) fails with:

```
error: expected a set but found a string: ""
```

## Root Cause

The `toCss` function in `flake.nix` assumes every value in the `custom-ui-style.stylesheet` JSON object is a nested attrset of CSS selector rules. However, `settings.json` contains a JSON comment entry at line 639:

```json
"// ─── end ───": ""
```

This entry's value is an empty string `""`, not an attrset. When `toCss` calls `mapAttrsToList` on it expecting `{ prop: value, ... }`, Nix throws `expected a set but found a string: ""`.

## Fix

Added `pkgs.lib.filterAttrs (_: v: builtins.isAttrs v)` to filter out any non-attrset entries before processing, so comment-style keys in the JSON are silently skipped.

Fixes #156